### PR TITLE
refactor(review): redesign the PR summary as a clear, direction-consistent metric checklist

### DIFF
--- a/internal/review/render.go
+++ b/internal/review/render.go
@@ -30,21 +30,124 @@ func (r *Result) EvaluateGate(level string) string {
 
 func (r *Result) headline() string {
 	if r.Gate == "failed" {
-		return "AST Metrics: quality gate failed"
+		return "AST Metrics found blocking regressions"
 	}
-	return "AST Metrics: quality gate passed"
+	if len(r.Regressions) > 0 {
+		return "AST Metrics found regressions"
+	}
+	return "AST Metrics found no regression"
 }
 
 func (r *Result) statsLine() string {
 	parts := []string{}
-	changed := r.Summary.FilesChanged + r.Summary.FilesAdded + r.Summary.FilesDeleted
-	parts = append(parts, fmt.Sprintf("%d file(s) changed", changed))
 	parts = append(parts, fmt.Sprintf("%d new critical issue(s)", r.Summary.High))
 	parts = append(parts, fmt.Sprintf("%d other regression(s)", r.Summary.Medium+r.Summary.Low))
 	if r.Summary.Improvements > 0 {
 		parts = append(parts, fmt.Sprintf("%d improvement(s)", r.Summary.Improvements))
 	}
 	return strings.Join(parts, ", ")
+}
+
+// metricDelta is the net change of a metric family across every finding,
+// e.g. every complexity regression and improvement summed together.
+type metricDelta struct {
+	label          string
+	delta          float64
+	decimals       int
+	higherIsBetter bool
+}
+
+// metricFamilies lists every checklist line, in display order: the internal
+// key used to sum matching findings, the label shown to the reader, how many
+// decimals its delta needs (Bugs is a small fractional estimate, everything
+// else is effectively an integer count), and whether a rising value is good
+// news (Maintainability) or bad news (everything else).
+//
+// The delta itself is always the natural After - Before change, so the
+// number reads the same way an English sentence would ("Complexity: +7"
+// means complexity went up by 7); the icon alone judges whether that
+// direction is good or bad, so numbers never have to lie about their sign
+// to fit a single "positive is always better" convention.
+var metricFamilies = []struct {
+	key            string
+	label          string
+	decimals       int
+	higherIsBetter bool
+}{
+	{"Complexity", "Complexity", 0, false},
+	{"Maintainability", "Ease of maintenance", 0, true},
+	{"Coupling", "Outgoing dependencies", 0, false},
+	{"Bugs", "Probability of bugs", 2, false},
+}
+
+// metricDeltas aggregates Before/After across all findings, grouped by
+// metric family, in a fixed display order. Every family is always returned,
+// even with a zero delta, so the report always shows the full checklist
+// rather than only the metrics that happened to have a finding.
+func (r *Result) metricDeltas() []metricDelta {
+	sums := map[string]float64{}
+	for _, family := range metricFamilies {
+		sums[family.key] = 0
+	}
+
+	add := func(f Finding) {
+		switch {
+		case f.Rule == "new-complex-function" || strings.HasPrefix(f.Rule, "complexity-"):
+			sums["Complexity"] += f.After - f.Before
+		case strings.HasPrefix(f.Rule, "maintainability-"):
+			sums["Maintainability"] += f.After - f.Before
+		case f.Rule == "coupling-regression":
+			sums["Coupling"] += f.After - f.Before
+		case strings.HasPrefix(f.Rule, "bugs-"):
+			sums["Bugs"] += f.After - f.Before
+		}
+	}
+	for _, f := range r.Regressions {
+		add(f)
+	}
+	for _, f := range r.Improvements {
+		add(f)
+	}
+
+	deltas := make([]metricDelta, 0, len(metricFamilies))
+	for _, family := range metricFamilies {
+		deltas = append(deltas, metricDelta{
+			label:          family.label,
+			delta:          sums[family.key],
+			decimals:       family.decimals,
+			higherIsBetter: family.higherIsBetter,
+		})
+	}
+	return deltas
+}
+
+// icon is a per-line status marker, so the good/bad signal sits next to each
+// metric instead of being collapsed into a single icon on the headline. The
+// trailing space is part of the icon itself: "⚠️" renders narrower than "✅"
+// and "➖" in most fonts, so it needs an extra space to stay aligned with
+// the others.
+func (d metricDelta) icon() string {
+	if d.delta == 0 {
+		return "➖ "
+	}
+	improved := d.delta < 0
+	if d.higherIsBetter {
+		improved = d.delta > 0
+	}
+	if improved {
+		return "✅ "
+	}
+	return "⚠️  "
+}
+
+// describe renders the signed, natural delta. The icon already carries the
+// good/bad signal, so the number can stay compact and honest about what
+// actually changed.
+func (d metricDelta) describe() string {
+	if d.delta == 0 {
+		return fmt.Sprintf("%s: -", d.label)
+	}
+	return fmt.Sprintf("%s: %+.*f", d.label, d.decimals, d.delta)
 }
 
 func (f *Finding) title() string {
@@ -66,6 +169,11 @@ func (r *Result) Text(maxFindings int) string {
 	var b strings.Builder
 	b.WriteString(r.headline() + "\n\n")
 	b.WriteString(r.statsLine() + "\n")
+
+	b.WriteString("\nSummary:\n")
+	for _, d := range r.metricDeltas() {
+		b.WriteString("- " + d.icon() + d.describe() + "\n")
+	}
 
 	if len(r.Regressions) > 0 {
 		b.WriteString("\nRegressions:\n")
@@ -93,7 +201,6 @@ func (r *Result) Text(maxFindings int) string {
 		}
 	}
 
-	b.WriteString("\nExisting debt is not reported. Methodology v" + MethodologyVersion + "\n")
 	return b.String()
 }
 
@@ -101,14 +208,13 @@ func (r *Result) Text(maxFindings int) string {
 func (r *Result) Markdown(maxFindings int) string {
 	var b strings.Builder
 
-	icon := "✅"
-	if r.Gate == "failed" {
-		icon = "❌"
-	} else if len(r.Regressions) > 0 {
-		icon = "⚠️"
-	}
-	b.WriteString("## " + icon + " " + r.headline() + "\n\n")
+	b.WriteString("## " + r.headline() + "\n\n")
 	b.WriteString(r.statsLine() + "\n")
+
+	b.WriteString("\n### Summary\n\n")
+	for _, d := range r.metricDeltas() {
+		b.WriteString("- " + d.icon() + "**" + d.describe() + "**\n")
+	}
 
 	if len(r.Regressions) > 0 {
 		b.WriteString("\n### Regressions\n\n")
@@ -140,8 +246,6 @@ func (r *Result) Markdown(maxFindings int) string {
 		b.WriteString("\nNo architectural change detected on modified code.\n")
 	}
 
-	b.WriteString("\n---\n")
-	b.WriteString(fmt.Sprintf("_Compared with `%s`. Existing debt is not reported. Methodology v%s._\n", r.BaseRef, MethodologyVersion))
 	return b.String()
 }
 

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -15,7 +15,7 @@ import (
 // MethodologyVersion identifies the formulas and thresholds used to compute
 // findings. It must be bumped whenever a threshold or a formula changes, so
 // that users can distinguish a code evolution from a calculation evolution.
-const MethodologyVersion = "1.0"
+const MethodologyVersion = "1.1"
 
 type Severity string
 
@@ -89,6 +89,10 @@ type Options struct {
 	ImprovementComplexityDrop int
 	// Minimum maintainability gain to report an improvement
 	ImprovementMaintainabilityGain float64
+	// Minimum increase of the Halstead estimated bugs to report a file
+	BugsIncrease float64
+	// Minimum decrease of the Halstead estimated bugs to report an improvement
+	BugsDrop float64
 }
 
 func DefaultOptions() Options {
@@ -102,6 +106,8 @@ func DefaultOptions() Options {
 		CouplingIncrease:               3,
 		ImprovementComplexityDrop:      3,
 		ImprovementMaintainabilityGain: 5,
+		BugsIncrease:                   0.1,
+		BugsDrop:                       0.1,
 	}
 }
 
@@ -332,6 +338,35 @@ func findingsForModifiedFile(head *pb.File, base *pb.File, path string, opts Opt
 		})
 	}
 
+	// Halstead estimated bugs, at file level
+	headBugs, headHasBugs := bugsOf(head)
+	baseBugs, baseHasBugs := bugsOf(base)
+	if headHasBugs && baseHasBugs {
+		if headBugs-baseBugs >= opts.BugsIncrease {
+			regressions = append(regressions, Finding{
+				Kind:       KindRegression,
+				Severity:   SeverityLow,
+				Rule:       "bugs-regression",
+				File:       path,
+				Message:    fmt.Sprintf("Estimated bugs (Halstead): %.2f -> %.2f", baseBugs, headBugs),
+				Suggestion: "This estimate grows with code volume and complexity; consider simplifying or splitting this file",
+				Before:     baseBugs,
+				After:      headBugs,
+			})
+		}
+		if baseBugs-headBugs >= opts.BugsDrop {
+			improvements = append(improvements, Finding{
+				Kind:     KindImprovement,
+				Severity: SeverityLow,
+				Rule:     "bugs-improvement",
+				File:     path,
+				Message:  fmt.Sprintf("Estimated bugs (Halstead): %.2f -> %.2f", baseBugs, headBugs),
+				Before:   baseBugs,
+				After:    headBugs,
+			})
+		}
+	}
+
 	return regressions, improvements
 }
 
@@ -453,6 +488,13 @@ func efferentOf(file *pb.File) (int32, bool) {
 		return 0, false
 	}
 	return file.Stmts.Analyze.Coupling.Efferent, true
+}
+
+func bugsOf(file *pb.File) (float64, bool) {
+	if file == nil || file.Stmts == nil || file.Stmts.Analyze == nil || file.Stmts.Analyze.Volume == nil || file.Stmts.Analyze.Volume.HalsteadBugs == nil {
+		return 0, false
+	}
+	return *file.Stmts.Analyze.Volume.HalsteadBugs, true
 }
 
 func relativize(path string, root string) string {

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -256,11 +256,10 @@ func TestMarkdownOutput(t *testing.T) {
 	result.Gate = result.EvaluateGate("never")
 
 	md := result.Markdown(5)
-	assert.Contains(t, md, "quality gate passed")
+	assert.Contains(t, md, "AST Metrics found regressions")
 	assert.Contains(t, md, "Pay")
 	assert.Contains(t, md, "svc.go:10")
-	assert.Contains(t, md, "Methodology v"+MethodologyVersion)
-	assert.Contains(t, md, "origin/main")
+	assert.Contains(t, md, "Complexity: +7")
 }
 
 func TestTextOutputCapsFindings(t *testing.T) {


### PR DESCRIPTION
Improved the markdown report.

Example:

```markdown
## AST Metrics found regressions

1 new critical issue(s), 3 other regression(s)

### Summary

- ⚠️  **Complexity: +3**
- ➖ **Ease of maintenance: -**
- ➖ **Outgoing dependencies: -**
- ➖ **Probability of bugs: -**

### Regressions

- **internal/review/render.go** (`internal/review/render.go:53`, high)
  Maintainability too low: got 62 (min: 70)
- **internal/review/render.go** (`internal/review/render.go:87`, medium)
  LOC too high in method metricDeltas(): got 36 (max: 30)
- **findingsForModifiedFile** (`internal/review/review.go:224`, medium)
  Cyclomatic complexity: 13 -> 16 (threshold: 10)
  Suggested action: Extract smaller, well-named functions to reduce decision points
- **internal/analyzer/ruleset/rule_golang_slice_prealloc_test.go** (`internal/analyzer/ruleset/rule_golang_slice_prealloc_test.go`, low)
  Found 1 loop(s) appending to a slice with known bound; consider preallocating capacity with make(T, 0, n) in internal/analyzer/ruleset/rule_golang_slice_prealloc_test.go
```