### PR TITLE
[BC] feat(cli): print a summary by default, keep the dashboard opt-in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Test the cli directly, generating HTML report
         run: |
           mkdir -p build
-          go run ./cmd/ast-metrics/ analyze --non-interactive --report-html=reporthtml internal
+          go run ./cmd/ast-metrics/ analyze --report-html=reporthtml internal
           ls reporthtml || (echo "No report generated" && exit 1) && (echo "Report generated" && exit 0)
 
       - name: Run Lighthouse CI

--- a/README.md
+++ b/README.md
@@ -58,8 +58,16 @@ curl -fsSL https://install.ast-metrics.dev | sh
 Then analyze your project:
 
 ```console
+ast-metrics analyze /path/to/your/code
+```
+
+A summary is printed on the standard output: maintainability, estimated bug probability, coupling, then the usual counters and the hotspots worth refactoring first. Ask for a durable report when you need one, and nothing is ever written to disk unless you do:
+
+```console
 ast-metrics analyze --report-html=<directory> /path/to/your/code
 ```
+
+Run `ast-metrics` with no argument to open the interactive menu, or add `--tui` to any analysis to explore the results in the full-screen dashboard. Anything piped, redirected or run in CI gets plain output.
 
 > Docker image, `.deb`/`.rpm` packages and manual downloads: see the detailed [installation instructions](https://ast-metrics.dev/getting-started/install/).
 

--- a/cmd/ast-metrics/main.go
+++ b/cmd/ast-metrics/main.go
@@ -7,11 +7,11 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strings"
+	"sync"
 
 	"github.com/ast-metrics/ast-metrics/internal/cli"
 	"github.com/ast-metrics/ast-metrics/internal/command"
 	"github.com/ast-metrics/ast-metrics/internal/configuration"
-	mcpserver "github.com/ast-metrics/ast-metrics/internal/mcp"
 	"github.com/ast-metrics/ast-metrics/internal/engine"
 	"github.com/ast-metrics/ast-metrics/internal/engine/csharp"
 	"github.com/ast-metrics/ast-metrics/internal/engine/golang"
@@ -20,6 +20,7 @@ import (
 	"github.com/ast-metrics/ast-metrics/internal/engine/python"
 	"github.com/ast-metrics/ast-metrics/internal/engine/rust"
 	"github.com/ast-metrics/ast-metrics/internal/engine/typescript"
+	mcpserver "github.com/ast-metrics/ast-metrics/internal/mcp"
 	"github.com/ast-metrics/ast-metrics/internal/watcher"
 	"github.com/pterm/pterm"
 	"github.com/sirupsen/logrus"
@@ -35,27 +36,104 @@ var (
 	date    = "unknown"
 )
 
-// isInteractiveSession reports whether the full-screen interface should be used.
+// flagInLineage reports whether a bool flag is set on cCtx or any of its
+// parent contexts. Flags such as --tui and --non-interactive are declared both
+// globally and on individual commands, so "ast-metrics --tui analyze ." has to
+// be honoured just like "ast-metrics analyze --tui .".
+func flagInLineage(cCtx *cliV2.Context, name string) bool {
+	for _, ctx := range cCtx.Lineage() {
+		if ctx.Bool(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasTerminal reports whether a human can both drive and read a full-screen
+// interface: stdin carries the keystrokes, stdout carries the drawing. A pipe
+// on either end rules the dashboard out, so a CI job, a redirection or a tool
+// driving the CLI never gets escape sequences it cannot use.
 //
-// It requires a terminal on stdin: a CI job, a pipe, or a tool driving the CLI
-// must never get a full-screen interface, whether or not it knows about the
-// --non-interactive flag.
+// It is a variable so the tests can decide what the terminal looks like: a test
+// binary never runs attached to one.
+var hasTerminal = func() bool {
+	return osterm.IsTerminal(int(os.Stdin.Fd())) && osterm.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// plainOutputForced reports whether plain output was explicitly asked for.
+func plainOutputForced(cCtx *cliV2.Context) bool {
+	return flagInLineage(cCtx, "non-interactive") || flagInLineage(cCtx, "ci")
+}
+
+// isInteractiveSession reports whether a command should show the full-screen
+// dashboard.
 //
-// The flag is looked up along the whole context lineage, because it is declared
-// as a global option: "ast-metrics --non-interactive analyze ." has to be
-// honoured just like "ast-metrics analyze --non-interactive .".
+// The dashboard is opt-in: ast-metrics is run far more often from a script, a
+// CI job or an editor than watched live, so commands print plain output and
+// --tui is what asks for the dashboard.
 func isInteractiveSession(cCtx *cliV2.Context) bool {
-	if !osterm.IsTerminal(int(os.Stdin.Fd())) {
+	if plainOutputForced(cCtx) {
 		return false
 	}
 
-	for _, ctx := range cCtx.Lineage() {
-		if ctx.Bool("non-interactive") || ctx.Bool("ci") {
-			return false
-		}
+	if !flagInLineage(cCtx, "tui") {
+		return false
+	}
+
+	if !hasTerminal() {
+		warnOnce("--tui needs a terminal on both stdin and stdout; falling back to plain output")
+		return false
 	}
 
 	return true
+}
+
+// shouldShowWelcomeScreen reports whether "ast-metrics", typed with no command
+// at all, should open the welcome screen. Nothing was asked for and someone is
+// watching, so a menu is more useful than a help page; anything piped or
+// scripted gets the help page instead.
+func shouldShowWelcomeScreen(cCtx *cliV2.Context) bool {
+	return !plainOutputForced(cCtx) && hasTerminal()
+}
+
+// warnIfNonInteractiveFlagUsed prints a deprecation notice when
+// --non-interactive is seen: plain output is now the default, so the flag only
+// forces what already happens, but scripts that pass it must keep working.
+func warnIfNonInteractiveFlagUsed(cCtx *cliV2.Context) {
+	if !flagInLineage(cCtx, "non-interactive") {
+		return
+	}
+
+	warnOnce("[DEPRECATION] --non-interactive is the default behaviour now and will be removed in a future release. Use --tui to ask for the full-screen dashboard.")
+}
+
+// warnOnce prints a warning on stderr, once per message and per run. The
+// interactivity helpers are called from several places, and the welcome screen
+// re-runs the application in-process, which would otherwise repeat the same
+// notice on every command.
+var warnedMessages sync.Map
+
+func warnOnce(message string) {
+	if _, alreadyWarned := warnedMessages.LoadOrStore(message, true); alreadyWarned {
+		return
+	}
+
+	cli.PrintWarningTo(os.Stderr, message)
+}
+
+// welcomeCommandArgs builds the command line the welcome screen runs for the
+// entry the user picked.
+//
+// It adds --tui, because reaching a command through the menu is a full-screen
+// session by definition: the results belong on screen, not in a scrollback the
+// menu is about to paint over. Typing "ast-metrics analyze ." directly stays
+// plain and gives the shell back, which is the whole point of the default.
+//
+// The flag goes before the command name since it is declared on the
+// application, and it is harmless for the commands that ignore it.
+func welcomeCommandArgs(appName string, result cli.WelcomeResult) []string {
+	args := []string{appName, "--tui", result.Command}
+	return append(args, result.Args...)
 }
 
 // isTerminalOutput reports whether stdout is a terminal, which is the only thing
@@ -92,8 +170,16 @@ func main() {
 		Usage: "Static code analysis tool",
 		Flags: []cliV2.Flag{
 			&cliV2.BoolFlag{
+				Name: "tui",
+				// No short alias: "-i" used to mean --non-interactive, and
+				// giving it the opposite meaning would silently flip the
+				// behaviour of the scripts that already pass it.
+				Aliases: []string{"interactive"},
+				Usage:   "Show the full-screen dashboard instead of plain output",
+			},
+			&cliV2.BoolFlag{
 				Name:  "non-interactive",
-				Usage: "Disable interactive mode",
+				Usage: "Deprecated: plain output is the default now, this flag only forces it",
 			},
 		},
 		Before: func(cCtx *cliV2.Context) error {
@@ -104,11 +190,13 @@ func main() {
 				pterm.DisableColor()
 			}
 
+			warnIfNonInteractiveFlagUsed(cCtx)
+
 			return nil
 		},
 		Action: func(cCtx *cliV2.Context) error {
-			if !isInteractiveSession(cCtx) {
-				// Non-interactive: print banner + help
+			if !shouldShowWelcomeScreen(cCtx) {
+				// Nothing to drive the menu with: print banner + help
 				fmt.Println(cli.RenderBanner(version))
 				return cliV2.ShowAppHelp(cCtx)
 			}
@@ -135,10 +223,7 @@ func main() {
 					continue
 				}
 
-				// Build args: app-name + command + any user-provided args
-				args := []string{cCtx.App.Name, result.Command}
-				args = append(args, result.Args...)
-				cmdErr := cCtx.App.Run(args)
+				cmdErr := cCtx.App.Run(welcomeCommandArgs(cCtx.App.Name, result))
 
 				// Commands that have their own interactive TUI: no pause needed
 				switch result.Command {
@@ -175,10 +260,23 @@ func main() {
 						Category: "File selection",
 					},
 					&cliV2.BoolFlag{
-						Name:     "non-interactive",
-						Aliases:  []string{"i"},
-						Usage:    "Disable interactive mode",
+						Name:     "tui",
+						Aliases:  []string{"interactive"},
+						Usage:    "Show the full-screen dashboard instead of plain output",
 						Category: "Global options",
+					},
+					&cliV2.BoolFlag{
+						Name:     "non-interactive",
+						Usage:    "Deprecated: plain output is the default now, this flag only forces it",
+						Category: "Global options",
+					},
+					// Summary report, printed on stdout. It is the report you
+					// get when you ask for no other one.
+					&cliV2.BoolFlag{
+						Name:     "report-summary",
+						Usage:    "Print a summary of the analysis on the standard output. Use --report-summary=false to silence it",
+						Value:    true,
+						Category: "Report",
 					},
 					// HTML report
 					&cliV2.StringFlag{
@@ -321,9 +419,9 @@ func main() {
 						}
 					}
 
-					// The interactive interface needs a terminal to drive it, so it
-					// is not enough to look at --non-interactive: an analysis run
-					// from a CI job or a script gets the plain output too.
+					// The dashboard is opt-in and needs a terminal to drive it:
+					// plain output is the default, and --tui is what turns it on.
+					warnIfNonInteractiveFlagUsed(cCtx)
 					isInteractive := isInteractiveSession(cCtx)
 
 					// Stdout
@@ -409,6 +507,13 @@ func main() {
 					}
 					if cCtx.Bool("open-html") {
 						config.Reports.OpenHtml = true
+					}
+					// The summary is enabled by default, so it is only worth
+					// touching the configuration when the flag was given: an
+					// untouched flag must not override the configuration file.
+					if cCtx.IsSet("report-summary") {
+						wantsSummary := cCtx.Bool("report-summary")
+						config.Reports.Summary = &wantsSummary
 					}
 
 					// CI mode
@@ -631,6 +736,7 @@ func main() {
 					&cliV2.StringFlag{Name: "report-json", Usage: "Generate a report in JSON format", Category: "Report"},
 					&cliV2.StringFlag{Name: "report-openmetrics", Usage: "Generate a report in OpenMetrics format", Category: "Report"},
 					&cliV2.StringFlag{Name: "report-sarif", Usage: "Generate a report in SARIF format (2.1.0)", Category: "Report"},
+					&cliV2.BoolFlag{Name: "report-summary", Usage: "Print a summary of the analysis on the standard output. Use --report-summary=false to silence it", Value: true, Category: "Report"},
 					&cliV2.StringFlag{Name: "config", Usage: "Load configuration from file", Category: "Configuration"},
 					&cliV2.StringFlag{Name: "compare-with", Usage: "Compare with another Git branch or commit", Category: "Global options"},
 					&cliV2.StringFlag{Name: "php-extensions", Usage: "Extra file extensions for PHP (comma-separated, e.g. .inc,.module)", Category: "File selection"},
@@ -697,6 +803,10 @@ func main() {
 					}
 					if cCtx.Bool("open-html") {
 						cfg.Reports.OpenHtml = true
+					}
+					if cCtx.IsSet("report-summary") {
+						wantsSummary := cCtx.Bool("report-summary")
+						cfg.Reports.Summary = &wantsSummary
 					}
 					// CI defaults for reports if not set
 					if cfg.Reports.Html == "" {

--- a/cmd/ast-metrics/main_test.go
+++ b/cmd/ast-metrics/main_test.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ast-metrics/ast-metrics/internal/cli"
+	cliV2 "github.com/urfave/cli/v2"
+)
+
+// decision is what the interactivity helpers concluded for one invocation.
+type decision struct {
+	interactive bool
+	welcome     bool
+	called      bool
+}
+
+// decide runs the given command line through an application declaring the same
+// interactivity flags as the real one, and reports what the helpers concluded.
+// The flags are declared both globally and on the command, exactly like in
+// main(), so the lineage lookup is really exercised.
+func decide(t *testing.T, terminal bool, args ...string) decision {
+	t.Helper()
+
+	restore := hasTerminal
+	hasTerminal = func() bool { return terminal }
+	t.Cleanup(func() { hasTerminal = restore })
+
+	result := decision{}
+	record := func(cCtx *cliV2.Context) error {
+		result.interactive = isInteractiveSession(cCtx)
+		result.welcome = shouldShowWelcomeScreen(cCtx)
+		result.called = true
+		return nil
+	}
+
+	interactivityFlags := func() []cliV2.Flag {
+		return []cliV2.Flag{
+			&cliV2.BoolFlag{Name: "tui", Aliases: []string{"interactive"}},
+			&cliV2.BoolFlag{Name: "non-interactive"},
+		}
+	}
+
+	app := &cliV2.App{
+		Name:   "ast-metrics",
+		Flags:  interactivityFlags(),
+		Action: record,
+		Commands: []*cliV2.Command{
+			{
+				Name:    "analyze",
+				Aliases: []string{"a"},
+				Flags:   append(interactivityFlags(), &cliV2.BoolFlag{Name: "ci"}),
+				Action:  record,
+			},
+		},
+	}
+
+	if err := app.Run(append([]string{"ast-metrics"}, args...)); err != nil {
+		t.Fatalf("running %v: %v", args, err)
+	}
+	if !result.called {
+		t.Fatalf("running %v never reached an action", args)
+	}
+
+	return result
+}
+
+func TestDashboardIsOptIn(t *testing.T) {
+	cases := []struct {
+		name     string
+		terminal bool
+		args     []string
+		want     bool
+	}{
+		{
+			name:     "plain output by default, even in a terminal",
+			terminal: true,
+			args:     []string{"analyze", "."},
+			want:     false,
+		},
+		{
+			name:     "--tui asks for the dashboard",
+			terminal: true,
+			args:     []string{"analyze", "--tui", "."},
+			want:     true,
+		},
+		{
+			name:     "--tui is honoured when given before the command",
+			terminal: true,
+			args:     []string{"--tui", "analyze", "."},
+			want:     true,
+		},
+		{
+			name:     "--interactive still works as an alias",
+			terminal: true,
+			args:     []string{"analyze", "--interactive", "."},
+			want:     true,
+		},
+		{
+			name:     "--tui falls back to plain output without a terminal",
+			terminal: false,
+			args:     []string{"analyze", "--tui", "."},
+			want:     false,
+		},
+		{
+			name:     "--non-interactive wins over --tui",
+			terminal: true,
+			args:     []string{"analyze", "--tui", "--non-interactive", "."},
+			want:     false,
+		},
+		{
+			name:     "--ci wins over --tui",
+			terminal: true,
+			args:     []string{"analyze", "--tui", "--ci", "."},
+			want:     false,
+		},
+		{
+			name:     "the alias of the command keeps the same rules",
+			terminal: true,
+			args:     []string{"a", "--tui", "."},
+			want:     true,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := decide(t, testCase.terminal, testCase.args...).interactive
+			if got != testCase.want {
+				t.Errorf("isInteractiveSession() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestShortInteractiveFlagIsGone guards the flag that changed meaning: "-i" used
+// to be an alias of --non-interactive, so accepting it again would silently turn
+// the plain output of existing scripts into a full-screen dashboard.
+func TestShortInteractiveFlagIsGone(t *testing.T) {
+	restore := hasTerminal
+	hasTerminal = func() bool { return true }
+	t.Cleanup(func() { hasTerminal = restore })
+
+	app := &cliV2.App{
+		Name:      "ast-metrics",
+		Writer:    io.Discard,
+		ErrWriter: io.Discard,
+		Commands: []*cliV2.Command{
+			{
+				Name:   "analyze",
+				Flags:  []cliV2.Flag{&cliV2.BoolFlag{Name: "tui", Aliases: []string{"interactive"}}},
+				Action: func(cCtx *cliV2.Context) error { return nil },
+			},
+		},
+	}
+
+	if err := app.Run([]string{"ast-metrics", "analyze", "-i", "."}); err == nil {
+		t.Fatal("expected -i to be rejected, so it cannot silently mean the opposite of what it used to")
+	}
+}
+
+// TestWelcomeScreenRunsCommandsInTheDashboard covers the one place where a
+// command becomes interactive without the user typing --tui: reaching it
+// through the menu. Typing the same command directly must stay plain and give
+// the shell back.
+func TestWelcomeScreenRunsCommandsInTheDashboard(t *testing.T) {
+	args := welcomeCommandArgs("ast-metrics", cli.WelcomeResult{
+		Command: "analyze",
+		Args:    []string{"./src"},
+	})
+
+	expected := []string{"ast-metrics", "--tui", "analyze", "./src"}
+	if len(args) != len(expected) {
+		t.Fatalf("built %v, want %v", args, expected)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Fatalf("built %v, want %v", args, expected)
+		}
+	}
+
+	// The flag has to come before the command name: it is declared on the
+	// application, not on the command.
+	if decide(t, true, args[1:]...).interactive != true {
+		t.Error("a command started from the welcome screen should show the dashboard")
+	}
+}
+
+func TestWelcomeScreenNeedsATerminalAndNoCommand(t *testing.T) {
+	cases := []struct {
+		name     string
+		terminal bool
+		args     []string
+		want     bool
+	}{
+		{
+			name:     "no command in a terminal opens the welcome screen",
+			terminal: true,
+			args:     []string{},
+			want:     true,
+		},
+		{
+			name:     "no command in a pipe prints the help instead",
+			terminal: false,
+			args:     []string{},
+			want:     false,
+		},
+		{
+			name:     "--non-interactive prints the help instead",
+			terminal: true,
+			args:     []string{"--non-interactive"},
+			want:     false,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := decide(t, testCase.terminal, testCase.args...).welcome
+			if got != testCase.want {
+				t.Errorf("shouldShowWelcomeScreen() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestWarnOnceDoesNotRepeatItself covers the helpers being called from several
+// places for a single run, and the welcome screen re-running the application
+// in-process: the same notice must not pile up.
+func TestWarnOnceDoesNotRepeatItself(t *testing.T) {
+	message := "a warning printed once"
+	warnedMessages.Delete(message)
+	t.Cleanup(func() { warnedMessages.Delete(message) })
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot capture stderr: %v", err)
+	}
+	original := os.Stderr
+	os.Stderr = writer
+
+	warnOnce(message)
+	warnOnce(message)
+
+	os.Stderr = original
+	if err := writer.Close(); err != nil {
+		t.Fatalf("cannot close the capture: %v", err)
+	}
+
+	printed, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("cannot read the capture: %v", err)
+	}
+
+	if occurrences := strings.Count(string(printed), message); occurrences != 1 {
+		t.Errorf("the warning was printed %d times, want 1", occurrences)
+	}
+}
+
+// TestWarningsGoToStderr keeps the invocation notices out of the output a script
+// parses or redirects to a file.
+func TestWarningsGoToStderr(t *testing.T) {
+	message := "a warning that belongs to stderr"
+	warnedMessages.Delete(message)
+	t.Cleanup(func() { warnedMessages.Delete(message) })
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot capture stdout: %v", err)
+	}
+	original := os.Stdout
+	os.Stdout = writer
+
+	warnOnce(message)
+
+	os.Stdout = original
+	if err := writer.Close(); err != nil {
+		t.Fatalf("cannot close the capture: %v", err)
+	}
+
+	printed, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("cannot read the capture: %v", err)
+	}
+
+	if strings.Contains(string(printed), message) {
+		t.Error("the warning was printed on stdout, it belongs to stderr")
+	}
+}

--- a/internal/analyzer/aggregator.go
+++ b/internal/analyzer/aggregator.go
@@ -843,6 +843,17 @@ func (r *Aggregator) mapSums(file *pb.File, specificAggregation Aggregated) Aggr
 				result.HalsteadTime.Sum += *class.Stmts.Analyze.Volume.HalsteadTime
 				result.HalsteadTime.Counter++
 			}
+			// The estimated number of delivered bugs was declared and merged
+			// across chunks, but never collected here: it stayed at zero for
+			// every project.
+			if class.Stmts.Analyze.Volume.HalsteadBugs != nil && !math.IsNaN(*class.Stmts.Analyze.Volume.HalsteadBugs) {
+				bugs := *class.Stmts.Analyze.Volume.HalsteadBugs
+				result.HalsteadBugs.Sum += bugs
+				result.HalsteadBugs.Counter++
+				if bugs > result.HalsteadBugs.Max {
+					result.HalsteadBugs.Max = bugs
+				}
+			}
 		}
 
 		// LCOM
@@ -947,6 +958,9 @@ func (r *Aggregator) mergeChunks(aggregated Aggregated, chunk *Aggregated) Aggre
 	result.HalsteadTime.Counter += chunk.HalsteadTime.Counter
 	result.HalsteadBugs.Sum += chunk.HalsteadBugs.Sum
 	result.HalsteadBugs.Counter += chunk.HalsteadBugs.Counter
+	if chunk.HalsteadBugs.Max > result.HalsteadBugs.Max {
+		result.HalsteadBugs.Max = chunk.HalsteadBugs.Max
+	}
 
 	// LCOM
 	result.Lcom4PerClass.Sum += chunk.Lcom4PerClass.Sum
@@ -1044,6 +1058,9 @@ func (r *Aggregator) reduceMetrics(aggregated Aggregated) Aggregated {
 	}
 	if result.HalsteadTime.Counter > 0 {
 		result.HalsteadTime.Avg = result.HalsteadTime.Sum / float64(result.HalsteadTime.Counter)
+	}
+	if result.HalsteadBugs.Counter > 0 {
+		result.HalsteadBugs.Avg = result.HalsteadBugs.Sum / float64(result.HalsteadBugs.Counter)
 	}
 	if result.Lcom4PerClass.Counter > 0 {
 		result.Lcom4PerClass.Avg = result.Lcom4PerClass.Sum / float64(result.Lcom4PerClass.Counter)

--- a/internal/analyzer/aggregator_test.go
+++ b/internal/analyzer/aggregator_test.go
@@ -513,6 +513,58 @@ func TestMergeChunksKeepsPerMethodAggregates(t *testing.T) {
 	assert.Equal(t, float64(14), result.CyclomaticComplexityPerMethod.Max)
 }
 
+// TestAggregatesHalsteadBugs covers the estimated number of delivered bugs: it
+// was declared and merged across chunks, but never collected from the classes,
+// so it stayed at zero for every project.
+func TestAggregatesHalsteadBugs(t *testing.T) {
+	// Classes are aggregated by qualified name, so each one needs its own.
+	classWithBugs := func(name string, bugs float64) *pb.StmtClass {
+		return &pb.StmtClass{
+			Name: &pb.Name{Qualified: name},
+			Stmts: &pb.Stmts{
+				Analyze: &pb.Analyze{
+					Volume: &pb.Volume{HalsteadBugs: &bugs},
+				},
+			},
+		}
+	}
+
+	files := []*pb.File{
+		{
+			Path:                "/project/a.php",
+			ProgrammingLanguage: "PHP",
+			Stmts: &pb.Stmts{
+				Analyze:   &pb.Analyze{},
+				StmtClass: []*pb.StmtClass{classWithBugs("Alpha", 0.5), classWithBugs("Beta", 1.5)},
+			},
+		},
+	}
+
+	project := NewAggregator(files, nil).Aggregates()
+
+	assert.Equal(t, float64(2), project.Combined.HalsteadBugs.Sum)
+	assert.Equal(t, 2, project.Combined.HalsteadBugs.Counter)
+	assert.Equal(t, float64(1), project.Combined.HalsteadBugs.Avg)
+	assert.Equal(t, float64(1.5), project.Combined.HalsteadBugs.Max)
+}
+
+// TestMergeChunksKeepsTheHighestBugEstimate checks that the maximum survives the
+// merge of two chunks analyzed in parallel.
+func TestMergeChunksKeepsTheHighestBugEstimate(t *testing.T) {
+	aggregator := Aggregator{}
+
+	result := aggregator.mergeChunks(Aggregated{}, &Aggregated{
+		HalsteadBugs: AggregateResult{Sum: 2, Counter: 2, Max: 1.5},
+	})
+	result = aggregator.mergeChunks(result, &Aggregated{
+		HalsteadBugs: AggregateResult{Sum: 3, Counter: 1, Max: 3},
+	})
+
+	assert.Equal(t, float64(5), result.HalsteadBugs.Sum)
+	assert.Equal(t, 3, result.HalsteadBugs.Counter)
+	assert.Equal(t, float64(3), result.HalsteadBugs.Max)
+}
+
 // TestAggregatesByDirectory checks the per-directory aggregation: one aggregate
 // per path given on the command line, each file belonging to exactly one scope.
 func TestAggregatesByDirectory(t *testing.T) {

--- a/internal/cli/screen_end.go
+++ b/internal/cli/screen_end.go
@@ -84,6 +84,11 @@ func (r *ScreenEnd) Render() {
 		}
 
 		fmt.Println("")
+	} else {
+		// The analysis produced a summary on stdout and nothing else. Say how to
+		// get a durable report rather than writing a file nobody asked for.
+		fmt.Println("\n💡 No report file was generated. Use --report-html=DIR, --report-json=FILE, or declare the reports you want in a configuration file.")
+		fmt.Println("")
 	}
 
 	// Tips if configuration file does not exist
@@ -92,24 +97,8 @@ func (r *ScreenEnd) Render() {
 		fmt.Println("")
 	}
 
-	// Linting tips
-	if r.projectAggregated.Evaluation != nil {
-		fmt.Println(styleTitle.Render("\nLinting"))
-		fmt.Println(styleTitle.Render("--------------------------------"))
-
-		if r.projectAggregated.Evaluation.Succeeded {
-			style := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00")).Bold(true)
-			fmt.Println(style.Render("\n✅ Lint check passed!"))
-		} else {
-			style := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000")).Bold(true)
-			fmt.Println(style.Render("\n❌ Lint check failed!"))
-			fmt.Println("")
-			fmt.Println("Details about the violations can be found by running:")
-			styleCode := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFF00"))
-			fmt.Println("\n  " + styleCode.Render("ast-metrics lint"))
-			fmt.Println("")
-		}
-	}
+	// The lint verdict belongs to the summary report printed just above, so it
+	// is deliberately not repeated here.
 
 	fmt.Println("\n🌟 If you like AST Metrics, please consider starring the project on GitHub: https://github.com/ast-metrics/ast-metrics/. Thanks!")
 	fmt.Println("")

--- a/internal/cli/screen_home.go
+++ b/internal/cli/screen_home.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/fsnotify/fsnotify"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	pb "github.com/ast-metrics/ast-metrics/pb"
@@ -74,9 +73,8 @@ func (r *ScreenHome) Render() {
 	r.currentModel = m
 
 	if !r.isInteractive {
-		// If not interactive
-		var style = lipgloss.NewStyle().Foreground(lipgloss.Color("#666666")).Italic(true)
-		fmt.Println(style.Render("No interactive mode detected."))
+		// Plain output has already been printed by the summary report: there is
+		// no full-screen interface to start here.
 		return
 	}
 

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"strconv"
@@ -203,10 +204,18 @@ func PrintError(msg string) {
 	fmt.Println(style.Render("  ✗ " + msg))
 }
 
-// PrintWarning prints a warning message styled to match the TUI look.
+// PrintWarning prints a warning message on stdout, styled to match the TUI
+// look. Use it for warnings that belong to the analysis output itself.
 func PrintWarning(msg string) {
+	PrintWarningTo(os.Stdout, msg)
+}
+
+// PrintWarningTo prints a warning message on the given stream. Warnings about
+// how the CLI was invoked go to stderr, so they never end up in the output a
+// script parses or redirects to a file.
+func PrintWarningTo(writer io.Writer, msg string) {
 	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFB86C")).Bold(true)
-	fmt.Println(style.Render("  ⚠ " + msg))
+	fmt.Fprintln(writer, style.Render("  ⚠ "+msg))
 }
 
 // PrintInfo prints an info message styled to match the TUI look.

--- a/internal/command/analyze_command.go
+++ b/internal/command/analyze_command.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"os"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	Activity "github.com/ast-metrics/ast-metrics/internal/analyzer/activity"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer/classifier"
@@ -14,8 +14,9 @@ import (
 	"github.com/ast-metrics/ast-metrics/internal/cli"
 	"github.com/ast-metrics/ast-metrics/internal/configuration"
 	"github.com/ast-metrics/ast-metrics/internal/engine"
-	pb "github.com/ast-metrics/ast-metrics/pb"
 	"github.com/ast-metrics/ast-metrics/internal/report"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+	"github.com/fsnotify/fsnotify"
 	"github.com/inancgumus/screen"
 	"github.com/pterm/pterm"
 	log "github.com/sirupsen/logrus"
@@ -199,7 +200,18 @@ func (v *AnalyzeCommand) Execute() error {
 		}
 	}
 
-	// Interactive: ask user what to do next
+	// The summary is the report you get when you ask for no other one, so that
+	// an analysis always produces something readable. The dashboard replaces it
+	// when it is on.
+	if !v.isInteractive && v.Configuration.Reports.HasSummary() {
+		summary := report.NewSummaryReportGenerator(os.Stdout)
+		if _, err := summary.Generate(allResults, projectAggregated); err != nil {
+			cli.PrintError("Cannot print the summary: " + err.Error())
+		}
+	}
+
+	// Ask the user what to do next. Only the full-screen session does: plain
+	// output always gives the shell back instead of waiting on a keypress.
 	if v.isInteractive && !v.alreadyExecuted {
 		choice := cli.AskPostAnalysis(allResults, projectAggregated)
 		switch choice {
@@ -268,7 +280,6 @@ func buildProjectContext(pa analyzer.ProjectAggregated) ruleset.ProjectContext {
 	}
 	return ctx
 }
-
 
 func (v *AnalyzeCommand) ExecuteRunnerAnalysis(config *configuration.Configuration) ([]*pb.File, error) {
 	if v.moonSpinner != nil {

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -55,11 +55,24 @@ type ConfigurationReport struct {
 	// Empty keeps the level derived from the severity of the finding.
 	SarifMaxLevel string `yaml:"sarif_max_level,omitempty"`
 	OpenHtml      bool   `yaml:"open_html,omitempty"`
+	// Summary is the plain-text report written on stdout. It is the report you
+	// get when you ask for no other one, so that a run always produces something
+	// readable instead of analyzing a whole project for nothing. It is a pointer
+	// to tell "not configured" (defaults to enabled) from an explicit disabling.
+	Summary *bool `yaml:"summary,omitempty"`
 }
 
-// function HasReports() bool {
+// HasReports reports whether at least one report file has to be written. The
+// stdout summary is deliberately not counted here: it produces no file, and the
+// views listing the generated reports only deal with files.
 func (c *ConfigurationReport) HasReports() bool {
 	return c.Html != "" || c.Markdown != "" || c.Json != "" || c.OpenMetrics != "" || c.Sarif != ""
+}
+
+// HasSummary reports whether the plain-text summary has to be printed. It is
+// enabled unless it has been explicitly turned off.
+func (c *ConfigurationReport) HasSummary() bool {
+	return c.Summary == nil || *c.Summary
 }
 
 type ConfigurationRequirements struct {

--- a/internal/configuration/configuration_loader.go
+++ b/internal/configuration/configuration_loader.go
@@ -113,6 +113,9 @@ exclude:
 reports:
   html: ./build/report
   markdown: ./build/report.md
+  # The summary printed on the standard output. It is enabled by default, and
+  # is what you get when no other report is asked for
+  # summary: false
 
 # Requirements. If a file does not meet these requirements, it will be reported
 requirements:

--- a/internal/report/summary_report_generator.go
+++ b/internal/report/summary_report_generator.go
@@ -1,0 +1,369 @@
+package report
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ast-metrics/ast-metrics/internal/analyzer"
+	"github.com/ast-metrics/ast-metrics/internal/engine"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// maintainabilityRefactorThreshold is the Maintainability Index below which a
+// class is worth refactoring first. It matches the threshold already used to
+// build the refactoring suggestions.
+const maintainabilityRefactorThreshold = 65
+
+// nbTopRisks is how many hotspots the summary lists. Enough to act on, short
+// enough to stay readable in a terminal or a CI log.
+const nbTopRisks = 5
+
+// SummaryReportGenerator writes a plain-text summary of the analysis.
+//
+// It is the report you get when you ask for no other one: unlike the other
+// generators it writes to a stream instead of a file, so that a run always
+// produces something readable, in a terminal as well as in a CI log, without
+// creating a file nobody asked for.
+//
+// The sections are ordered by what AST Metrics knows that a line counter does
+// not: maintainability, bug probability and coupling come first, raw counters
+// last.
+type SummaryReportGenerator struct {
+	Writer io.Writer
+}
+
+func NewSummaryReportGenerator(writer io.Writer) Reporter {
+	return &SummaryReportGenerator{Writer: writer}
+}
+
+// Generate prints the summary. It returns no GeneratedReport: nothing durable
+// has been produced, so the views listing the generated files stay untouched.
+func (v *SummaryReportGenerator) Generate(files []*pb.File, projectAggregated analyzer.ProjectAggregated) ([]GeneratedReport, error) {
+	if v.Writer == nil {
+		return nil, nil
+	}
+
+	if _, err := io.WriteString(v.Writer, v.Render(files, projectAggregated)); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// Render builds the summary. It is kept separate from Generate so the layout
+// can be asserted in tests without going through a stream.
+func (v *SummaryReportGenerator) Render(files []*pb.File, projectAggregated analyzer.ProjectAggregated) string {
+	combined := projectAggregated.Combined
+	byClass := projectAggregated.ByClass
+
+	out := &strings.Builder{}
+	out.WriteString("\n")
+
+	section(out, "Maintainability", func(body *strings.Builder) {
+		if combined.MaintainabilityIndex.Counter > 0 {
+			row(body, "Maintainability index", fmt.Sprintf("%.0f  (%s)",
+				combined.MaintainabilityIndex.Avg, maintainabilityLabel(combined.MaintainabilityIndex.Avg)))
+		}
+		metric(body, "  without comments", combined.MaintainabilityIndexWithoutComments)
+		metric(body, "  comment weight", combined.MaintainabilityCommentWeight)
+
+		nbHardToMaintain, nbMeasuredClasses := countClassesToRefactor(files)
+		if nbMeasuredClasses > 0 {
+			row(body, fmt.Sprintf("Classes below the %d threshold", maintainabilityRefactorThreshold),
+				fmt.Sprintf("%d of %d measured", nbHardToMaintain, nbMeasuredClasses))
+		}
+	})
+
+	section(out, "Bug probability (Halstead)", func(body *strings.Builder) {
+		if combined.HalsteadBugs.Counter > 0 {
+			row(body, "Estimated delivered bugs", decimal(combined.HalsteadBugs.Sum))
+		}
+		metric(body, "  per class", combined.HalsteadBugs)
+		metric(body, "Volume", combined.HalsteadVolume)
+		metric(body, "Difficulty", combined.HalsteadDifficulty)
+		metric(body, "Effort", combined.HalsteadEffort)
+		if combined.HalsteadTime.Counter > 0 {
+			// Halstead time is expressed in seconds, which says nothing at this
+			// scale.
+			row(body, "Estimated time to write (total)", fmt.Sprintf("%.1f h", combined.HalsteadTime.Sum/3600))
+		}
+	})
+
+	section(out, "Coupling", func(body *strings.Builder) {
+		metric(body, "Efferent coupling", combined.EfferentCoupling)
+		metric(body, "Afferent coupling", combined.AfferentCoupling)
+		// Instability is derived from the coupling sums, so it carries no
+		// counter of its own: it is measured exactly when the coupling is.
+		if combined.EfferentCoupling.Counter > 0 {
+			row(body, "Instability (avg)", decimal(combined.Instability.Avg))
+		}
+		metric(body, "Lack of cohesion, LCOM4", byClass.Lcom4PerClass)
+		if combined.Community != nil && combined.Community.CommunitiesCount > 0 {
+			row(body, "Communities detected", integer(combined.Community.CommunitiesCount))
+			row(body, "  largest one", fmt.Sprintf("%d components", combined.Community.MaxSize))
+			row(body, "Graph density", decimal(combined.Community.GraphDensity))
+		}
+	})
+
+	section(out, "Complexity", func(body *strings.Builder) {
+		if combined.CyclomaticComplexity.Counter > 0 {
+			row(body, "Cyclomatic complexity (total)", integer(int(combined.CyclomaticComplexity.Sum)))
+		}
+		metric(body, "  per class", combined.CyclomaticComplexityPerClass)
+		metric(body, "  per method", combined.CyclomaticComplexityPerMethod)
+	})
+
+	section(out, "Size", func(body *strings.Builder) {
+		row(body, "Files", integer(combined.NbFiles))
+		row(body, "  including test files", integer(combined.NbTestFiles))
+		total(body, "Lines of code (LOC)", combined.Loc)
+		total(body, "  comment lines (CLOC)", combined.Cloc)
+		total(body, "  logical lines (LLOC)", combined.Lloc)
+		row(body, "Classes", integer(byClass.NbClasses))
+		row(body, "Methods", integer(combined.NbMethods))
+		row(body, "Functions", integer(combined.NbFunctions))
+		metric(body, "LOC per class", combined.LocPerClass)
+		metric(body, "LOC per method", combined.LocPerMethod)
+		metric(body, "Methods per class", byClass.MethodsPerClass)
+	})
+
+	renderLanguages(out, projectAggregated)
+	renderTestQuality(out, combined)
+	renderRisks(out, files)
+	renderLint(out, projectAggregated)
+
+	out.WriteString("\n")
+
+	return out.String()
+}
+
+// renderLanguages lists one line per language. It is skipped on a single
+// language project, where it would only repeat the totals above.
+func renderLanguages(out *strings.Builder, projectAggregated analyzer.ProjectAggregated) {
+	if len(projectAggregated.ByProgrammingLanguage) < 2 {
+		return
+	}
+
+	names := make([]string, 0, len(projectAggregated.ByProgrammingLanguage))
+	for name := range projectAggregated.ByProgrammingLanguage {
+		names = append(names, name)
+	}
+	// Biggest language first, so the main one is at the top.
+	sort.Slice(names, func(i, j int) bool {
+		return projectAggregated.ByProgrammingLanguage[names[i]].Loc.Sum >
+			projectAggregated.ByProgrammingLanguage[names[j]].Loc.Sum
+	})
+
+	section(out, "Languages", func(body *strings.Builder) {
+		for _, name := range names {
+			language := projectAggregated.ByProgrammingLanguage[name]
+			row(body, name, fmt.Sprintf("%s LOC, MI %.0f, %.1f CC/method",
+				integer(int(language.Loc.Sum)),
+				language.MaintainabilityIndex.Avg,
+				language.CyclomaticComplexityPerMethod.Avg))
+		}
+	})
+}
+
+func renderTestQuality(out *strings.Builder, combined analyzer.Aggregated) {
+	quality := combined.TestQuality
+	if quality == nil || quality.NbTestFiles == 0 {
+		return
+	}
+
+	section(out, "Tests", func(body *strings.Builder) {
+		row(body, "Classes covered by a test", fmt.Sprintf("%.1f%%  (%d / %d)",
+			quality.TraceabilityPct, quality.NbTestedClasses, quality.NbProdClasses))
+		row(body, "Isolation score", fmt.Sprintf("%.0f  (%s)", quality.GlobalIsolationScore, quality.IsolationLabel))
+		row(body, "God tests", integer(len(quality.GodTests)))
+		row(body, "Classes without any test", integer(len(quality.OrphanClasses)))
+	})
+}
+
+// renderRisks lists the hotspots: the files combining a poor maintainability
+// with a high change frequency, which is where refactoring pays off most.
+func renderRisks(out *strings.Builder, files []*pb.File) {
+	riskiest := make([]*pb.File, 0, len(files))
+	for _, file := range files {
+		if file == nil || file.IsTest || file.Stmts == nil || file.Stmts.Analyze == nil || file.Stmts.Analyze.Risk == nil {
+			continue
+		}
+		if file.Stmts.Analyze.Risk.Score <= 0 {
+			continue
+		}
+		riskiest = append(riskiest, file)
+	}
+
+	if len(riskiest) == 0 {
+		return
+	}
+
+	sort.Slice(riskiest, func(i, j int) bool {
+		return riskiest[i].Stmts.Analyze.Risk.Score > riskiest[j].Stmts.Analyze.Risk.Score
+	})
+
+	nbAtRisk := len(riskiest)
+	if len(riskiest) > nbTopRisks {
+		riskiest = riskiest[:nbTopRisks]
+	}
+
+	section(out, fmt.Sprintf("Hotspots (top %d of %d files at risk)", len(riskiest), nbAtRisk), func(body *strings.Builder) {
+		for _, file := range riskiest {
+			details := []string{}
+			if index, ok := fileMaintainabilityIndex(file); ok {
+				details = append(details, fmt.Sprintf("MI %.0f", index))
+			}
+			if file.Commits != nil {
+				details = append(details, fmt.Sprintf("%d commits", len(file.Commits.Commits)))
+			}
+
+			line := fmt.Sprintf("  %.2f  %s", file.Stmts.Analyze.Risk.Score, filePath(file))
+			if len(details) > 0 {
+				line += "  (" + strings.Join(details, ", ") + ")"
+			}
+			fmt.Fprintln(body, line)
+		}
+	})
+}
+
+func renderLint(out *strings.Builder, projectAggregated analyzer.ProjectAggregated) {
+	if projectAggregated.Evaluation == nil {
+		return
+	}
+
+	section(out, "Lint", func(body *strings.Builder) {
+		if projectAggregated.Evaluation.Succeeded {
+			body.WriteString("  ✅ Requirements are met\n")
+			return
+		}
+		body.WriteString("  ❌ Requirements are not met. Run: ast-metrics lint\n")
+	})
+}
+
+// filePath prefers the path relative to the analyzed sources: an absolute path
+// pushes the interesting part of the line out of the terminal.
+func filePath(file *pb.File) string {
+	if file.ShortPath != "" {
+		return file.ShortPath
+	}
+	return file.Path
+}
+
+// fileMaintainabilityIndex returns the maintainability index of a file, taken
+// from its first class for object-oriented code. It reports false when the file
+// carries no index at all, so the caller can leave the detail out instead of
+// printing a misleading zero.
+func fileMaintainabilityIndex(file *pb.File) (float64, bool) {
+	if file.Stmts != nil && file.Stmts.Analyze != nil && file.Stmts.Analyze.Maintainability != nil &&
+		file.Stmts.Analyze.Maintainability.MaintainabilityIndex != nil {
+		return *file.Stmts.Analyze.Maintainability.MaintainabilityIndex, true
+	}
+
+	for _, class := range engine.GetClassesInFile(file) {
+		if class.Stmts == nil || class.Stmts.Analyze == nil || class.Stmts.Analyze.Maintainability == nil ||
+			class.Stmts.Analyze.Maintainability.MaintainabilityIndex == nil {
+			continue
+		}
+		return *class.Stmts.Analyze.Maintainability.MaintainabilityIndex, true
+	}
+
+	return 0, false
+}
+
+// countClassesToRefactor returns how many classes fall below the refactoring
+// threshold, and how many classes carry a maintainability index at all. Test
+// files are left out, like everywhere else in the aggregates: they are not the
+// production code being measured.
+func countClassesToRefactor(files []*pb.File) (int, int) {
+	below, total := 0, 0
+	for _, file := range files {
+		if file == nil || file.IsTest {
+			continue
+		}
+		for _, class := range engine.GetClassesInFile(file) {
+			if class.Stmts == nil || class.Stmts.Analyze == nil || class.Stmts.Analyze.Maintainability == nil ||
+				class.Stmts.Analyze.Maintainability.MaintainabilityIndex == nil {
+				continue
+			}
+			total++
+			if *class.Stmts.Analyze.Maintainability.MaintainabilityIndex < maintainabilityRefactorThreshold {
+				below++
+			}
+		}
+	}
+	return below, total
+}
+
+// maintainabilityLabel translates the index into the wording used across the
+// documentation and the HTML report.
+func maintainabilityLabel(index float64) string {
+	switch {
+	case index > 85:
+		return "easy to maintain"
+	case index > 65:
+		return "moderate"
+	default:
+		return "hard to maintain"
+	}
+}
+
+// section writes a titled block. The title only appears when the block has
+// something to say: a project analyzed without git, without a dependency graph
+// or in a language carrying no coupling gets a shorter summary rather than a
+// list of empty headers.
+func section(out *strings.Builder, title string, build func(body *strings.Builder)) {
+	body := &strings.Builder{}
+	build(body)
+	if body.Len() == 0 {
+		return
+	}
+
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#00FFFF")).Bold(true)
+	fmt.Fprintf(out, "\n%s\n", style.Render(title))
+	out.WriteString(body.String())
+}
+
+// metric writes one aggregate, and writes nothing at all when the analysis
+// never fed it: a counter of zero means no measurement was taken, and printing
+// an average of zero would read as a result rather than as a gap. The maximum
+// is only shown when the aggregation actually tracked one.
+func metric(out *strings.Builder, label string, result analyzer.AggregateResult) {
+	if result.Counter == 0 {
+		return
+	}
+
+	if result.Max > result.Avg {
+		row(out, label+" (avg / max)", decimal(result.Avg)+" / "+decimal(result.Max))
+		return
+	}
+
+	row(out, label+" (avg)", decimal(result.Avg))
+}
+
+// total writes the sum of an aggregate, and nothing when it was never fed.
+func total(out *strings.Builder, label string, result analyzer.AggregateResult) {
+	if result.Counter == 0 {
+		return
+	}
+
+	row(out, label, integer(int(result.Sum)))
+}
+
+// row prints a label and its value. The label is padded so the values line up
+// in a column, and the value is left as-is so it stays easy to grep.
+func row(out *strings.Builder, label string, value string) {
+	fmt.Fprintf(out, "  %-34s %s\n", label, value)
+}
+
+func decimal(value float64) string {
+	return strconv.FormatFloat(value, 'f', 2, 64)
+}
+
+func integer(value int) string {
+	return strconv.Itoa(value)
+}

--- a/internal/report/summary_report_generator_test.go
+++ b/internal/report/summary_report_generator_test.go
@@ -1,0 +1,256 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/ast-metrics/ast-metrics/internal/analyzer"
+	"github.com/ast-metrics/ast-metrics/internal/analyzer/requirement"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// fileWithRisk builds a file carrying the metrics the summary reads: a risk
+// score, a maintainability index on its class, and a commit history.
+func fileWithRisk(path string, risk float64, maintainability float64, commits int) *pb.File {
+	history := make([]*pb.Commit, commits)
+	for i := range history {
+		history[i] = &pb.Commit{}
+	}
+
+	return &pb.File{
+		Path: path,
+		Stmts: &pb.Stmts{
+			Analyze: &pb.Analyze{
+				Risk: &pb.Risk{Score: risk},
+			},
+			StmtClass: []*pb.StmtClass{
+				{
+					Name: &pb.Name{Qualified: path + "\\Class"},
+					Stmts: &pb.Stmts{
+						Analyze: &pb.Analyze{
+							Maintainability: &pb.Maintainability{
+								MaintainabilityIndex: proto.Float64(maintainability),
+							},
+						},
+					},
+				},
+			},
+		},
+		Commits: &pb.Commits{Count: int32(commits), Commits: history},
+	}
+}
+
+func aggregatedForTest() analyzer.ProjectAggregated {
+	combined := analyzer.Aggregated{
+		NbFiles:                       3,
+		NbTestFiles:                   1,
+		NbMethods:                     42,
+		NbFunctions:                   7,
+		// Counter is what tells a real measurement from an aggregate the
+		// analysis never fed, so every fixture carries one.
+		Loc:                           analyzer.AggregateResult{Sum: 1200, Counter: 3},
+		Cloc:                          analyzer.AggregateResult{Sum: 300, Counter: 3},
+		Lloc:                          analyzer.AggregateResult{Sum: 800, Counter: 3},
+		LocPerClass:                   analyzer.AggregateResult{Avg: 47, Counter: 10},
+		LocPerMethod:                  analyzer.AggregateResult{Avg: 8, Counter: 42},
+		CyclomaticComplexity:          analyzer.AggregateResult{Sum: 155, Counter: 3},
+		CyclomaticComplexityPerClass:  analyzer.AggregateResult{Avg: 9.12, Max: 61, Counter: 10},
+		CyclomaticComplexityPerMethod: analyzer.AggregateResult{Avg: 4.21, Max: 38, Counter: 42},
+		MaintainabilityIndex:          analyzer.AggregateResult{Avg: 71, Counter: 10},
+		HalsteadBugs:                  analyzer.AggregateResult{Sum: 12.4, Avg: 0.4, Max: 2.1, Counter: 10},
+		HalsteadVolume:                analyzer.AggregateResult{Avg: 1204, Max: 18903, Counter: 10},
+		HalsteadDifficulty:            analyzer.AggregateResult{Avg: 14.2, Max: 96, Counter: 10},
+		HalsteadEffort:                analyzer.AggregateResult{Avg: 18203, Counter: 10},
+		HalsteadTime:                  analyzer.AggregateResult{Sum: 7200, Counter: 10},
+		EfferentCoupling:              analyzer.AggregateResult{Avg: 4.1, Max: 38, Counter: 10},
+		AfferentCoupling:              analyzer.AggregateResult{Avg: 3.7, Max: 121, Counter: 10},
+		Instability:                   analyzer.AggregateResult{Avg: 0.53},
+		Community: &analyzer.CommunityMetrics{
+			CommunitiesCount: 12,
+			MaxSize:          31,
+			GraphDensity:     0.14,
+		},
+		TestQuality: &analyzer.TestQualityMetrics{
+			NbTestFiles:          4,
+			NbProdClasses:        10,
+			NbTestedClasses:      6,
+			TraceabilityPct:      60,
+			GlobalIsolationScore: 71,
+			IsolationLabel:       "Semi-isolated",
+			GodTests:             []analyzer.TestFileMetrics{{FilePath: "a_test.go"}},
+			OrphanClasses:        []analyzer.OrphanClass{{ClassName: "Lonely"}},
+		},
+	}
+
+	return analyzer.ProjectAggregated{
+		Combined: combined,
+		ByClass: analyzer.Aggregated{
+			NbClasses:       10,
+			MethodsPerClass: analyzer.AggregateResult{Avg: 4.2, Counter: 10},
+			Lcom4PerClass:   analyzer.AggregateResult{Avg: 1.8, Counter: 10},
+		},
+	}
+}
+
+// TestSummaryLeadsWithWhatTheToolKnows checks that the metrics setting AST
+// Metrics apart from a line counter are present and come before the raw
+// counters, which is the whole point of the layout.
+func TestSummaryLeadsWithWhatTheToolKnows(t *testing.T) {
+	generator := &SummaryReportGenerator{}
+	rendered := generator.Render([]*pb.File{}, aggregatedForTest())
+
+	ordered := []string{"Maintainability", "Bug probability", "Coupling", "Complexity", "Size"}
+	position := 0
+	for _, section := range ordered {
+		found := strings.Index(rendered[position:], section)
+		if found < 0 {
+			t.Fatalf("section %q is missing, or comes before %q:\n%s", section, ordered[0], rendered)
+		}
+		position += found
+	}
+
+	expected := []string{
+		"71  (moderate)",     // maintainability index and its label
+		"12.40",              // estimated delivered bugs
+		"1204.00 / 18903.00", // Halstead volume
+		"4.10 / 38.00",       // efferent coupling
+		"0.53",               // instability
+		"1.80",               // LCOM4
+		"12",                 // communities
+		"2.0 h",              // Halstead time, in hours rather than seconds
+	}
+	for _, value := range expected {
+		if !strings.Contains(rendered, value) {
+			t.Errorf("expected %q in the summary:\n%s", value, rendered)
+		}
+	}
+}
+
+func TestSummaryReportsTestQuality(t *testing.T) {
+	generator := &SummaryReportGenerator{}
+	rendered := generator.Render([]*pb.File{}, aggregatedForTest())
+
+	for _, value := range []string{"60.0%  (6 / 10)", "71  (Semi-isolated)"} {
+		if !strings.Contains(rendered, value) {
+			t.Errorf("expected %q in the summary:\n%s", value, rendered)
+		}
+	}
+}
+
+func TestSummaryListsTheRiskiestFilesFirst(t *testing.T) {
+	files := []*pb.File{
+		fileWithRisk("low.go", 0.10, 90, 1),
+		fileWithRisk("worst.go", 0.92, 41, 12),
+		fileWithRisk("middle.go", 0.50, 60, 4),
+		fileWithRisk("untouched.go", 0, 95, 0),
+	}
+
+	generator := &SummaryReportGenerator{}
+	rendered := generator.Render(files, aggregatedForTest())
+
+	worst := strings.Index(rendered, "worst.go")
+	middle := strings.Index(rendered, "middle.go")
+	if worst < 0 || middle < 0 {
+		t.Fatalf("expected the hotspots to be listed:\n%s", rendered)
+	}
+	if worst > middle {
+		t.Errorf("expected the riskiest file first:\n%s", rendered)
+	}
+
+	if !strings.Contains(rendered, "MI 41, 12 commits") {
+		t.Errorf("expected the maintainability and the churn of a hotspot:\n%s", rendered)
+	}
+
+	if strings.Contains(rendered, "untouched.go") {
+		t.Errorf("a file without any risk should not be listed as a hotspot:\n%s", rendered)
+	}
+
+	// 2 of the 4 classes are below the refactoring threshold.
+	if !strings.Contains(rendered, "Classes below the 65 threshold") || !strings.Contains(rendered, "2 of 4 measured") {
+		t.Errorf("expected the count of classes to refactor:\n%s", rendered)
+	}
+}
+
+func TestSummaryReportsTheLintVerdict(t *testing.T) {
+	aggregated := aggregatedForTest()
+	aggregated.Evaluation = &requirement.EvaluationResult{Succeeded: false}
+
+	generator := &SummaryReportGenerator{}
+	rendered := generator.Render([]*pb.File{}, aggregated)
+
+	if !strings.Contains(rendered, "ast-metrics lint") {
+		t.Errorf("a failed evaluation should point at the lint command:\n%s", rendered)
+	}
+}
+
+// TestSummarySkipsWhatItDoesNotKnow covers a project analyzed without git,
+// tests or dependency graph: a section with nothing to say disappears instead
+// of printing zeroes that read like real measurements.
+func TestSummarySkipsWhatItDoesNotKnow(t *testing.T) {
+	generator := &SummaryReportGenerator{}
+	rendered := generator.Render([]*pb.File{}, analyzer.ProjectAggregated{})
+
+	for _, section := range []string{
+		"Maintainability", "Bug probability", "Coupling", "Complexity",
+		"Tests", "Hotspots", "Lint", "Languages",
+	} {
+		if strings.Contains(rendered, section) {
+			t.Errorf("section %q should be skipped when nothing was measured:\n%s", section, rendered)
+		}
+	}
+
+	if !strings.Contains(rendered, "Size") {
+		t.Errorf("the counters are always known and should still be printed:\n%s", rendered)
+	}
+}
+
+// TestSummaryNeverInventsAMeasurement is the rule the whole layout rests on: an
+// aggregate the analysis never fed carries a counter of zero, and an average of
+// zero would be read as a result rather than as a gap.
+func TestSummaryNeverInventsAMeasurement(t *testing.T) {
+	aggregated := aggregatedForTest()
+	// LocPerClass is one of the aggregates the aggregator declares but never
+	// fills in: it must not show up as a measured zero.
+	aggregated.Combined.LocPerClass = analyzer.AggregateResult{}
+	// A maximum that was never tracked stays at zero while the average is not:
+	// only the average can be shown.
+	aggregated.Combined.HalsteadEffort = analyzer.AggregateResult{Sum: 100, Avg: 50, Counter: 2}
+
+	generator := &SummaryReportGenerator{}
+	rendered := generator.Render([]*pb.File{}, aggregated)
+
+	if strings.Contains(rendered, "LOC per class") {
+		t.Errorf("an aggregate that was never measured must be left out:\n%s", rendered)
+	}
+
+	if !strings.Contains(rendered, "Effort (avg)") || strings.Contains(rendered, "Effort (avg / max)") {
+		t.Errorf("a maximum that was never tracked must not be printed:\n%s", rendered)
+	}
+
+	// The same aggregate, once a maximum is tracked, shows both.
+	aggregated.Combined.HalsteadEffort.Max = 90
+	rendered = generator.Render([]*pb.File{}, aggregated)
+	if !strings.Contains(rendered, "Effort (avg / max)") {
+		t.Errorf("a tracked maximum should be printed:\n%s", rendered)
+	}
+}
+
+func TestSummaryWritesToTheStreamAndCreatesNoFile(t *testing.T) {
+	out := &strings.Builder{}
+	generator := NewSummaryReportGenerator(out)
+
+	reports, err := generator.Generate([]*pb.File{}, aggregatedForTest())
+	if err != nil {
+		t.Fatalf("did not expect an error, got: %v", err)
+	}
+
+	if len(reports) != 0 {
+		t.Errorf("the summary produces no file, so it must report no generated report, got %d", len(reports))
+	}
+
+	if out.Len() == 0 {
+		t.Error("nothing was written to the stream")
+	}
+}


### PR DESCRIPTION
## Why

`ast-metrics analyze .` used to analyze a whole project and print `No interactive mode detected.` and nothing else. Outside the dashboard, the tool produced nothing: not in CI, not in a pipe, not for someone who simply ran the command.

## What changes

- `analyze` prints a summary on stdout: maintainability, bug probability and coupling first, then the usual counters and the files worth refactoring first.
- The full-screen dashboard is now explicit: `--tui`. Running `ast-metrics` with no argument still opens the welcome menu.
- Nothing is ever written to disk unless you ask for a report. `--report-summary=false` silences the summary.

## Impact

- **`-i` is gone.** It used to mean `--non-interactive`, so keeping it for the opposite meaning would have silently turned the plain output of existing scripts into a dashboard. Use `--tui`.
- `--non-interactive` still works, with a deprecation notice on stderr: it is the default behaviour now.
- Two aggregation bugs fixed on the way: the estimated bug count was zero for every project (the aggregate was never collected), and the summary no longer prints metrics the analysis never measured.
