### PR TITLE
feat(php): Identify files ending with spec.php as test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ bin/protoc:
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	go install github.com/golang/protobuf/protoc-gen-go
 	@echo "\e[34m\033[1mDONE \033[0m\e[39m\n"
+
 build-protobuff: bin/protoc
 	@echo "\e[34m\033[1m-> Building protobuff\033[0m\e[39m\n"
 	rm -rf pb || true
@@ -23,16 +24,19 @@ build-protobuff: bin/protoc
 	echo 'THIS DIRECTORY IS BUILT BY MAKEFILE (make build-protobuff)' > pb/README.md
 	rm -rf pb/github.com || true
 	@echo "\e[34m\033[1mDONE \033[0m\e[39m\n"
+
 build-go: # for local development and tests
 	@echo "\e[34m\033[1m-> Building go binaries\033[0m\e[39m\n"
 	go build -o bin/ast-metrics ./cmd/ast-metrics
 	@echo "\e[34m\033[1mDONE \033[0m\e[39m\n"
+
 build-release:
 	@echo "\e[34m\033[1m-> Building go binaries for supported platforms\033[0m\e[39m\n"
 	rm -Rf dist || true
 	go install github.com/goreleaser/goreleaser@latest
 	GOPATH=$(shell go env GOPATH) PATH=$$PATH:$(shell go env GOPATH)/bin goreleaser build --snapshot
 	@echo "\e[34m\033[1mDONE \033[0m\e[39m\n"
+
 build: build-protobuff build-go
 	@echo "\n\e[42m  BUILD FINISHED  \e[49m\n"
 
@@ -54,7 +58,6 @@ profile:
 	go run ./cmd/ast-metrics a --non-interactive --profile .
 	go tool pprof -png  ast-metrics.cpu
 	go tool pprof -png  ast-metrics.mem
-
 
 dev-prepare-examples:
 	@echo "\e[34m\033[1m-> Preparing example projects for development\033[0m\e[39m\n"

--- a/internal/engine/php/php_runner.go
+++ b/internal/engine/php/php_runner.go
@@ -140,12 +140,12 @@ func (r *PhpRunner) getFileList() file.FileList {
 }
 
 // isTestFile determines if a PHP file is a test file based on:
-// 1. Filename pattern (ends with Test.php)
+// 1. Filename pattern (ends with Test.php or Spec.php)
 // 2. Class inheritance (extends PHPUnit\Framework\TestCase or similar test base classes)
 func (r PhpRunner) isTestFile(path string, file *pb.File) bool {
 	// Check filename pattern
 	baseName := strings.ToLower(path)
-	if strings.HasSuffix(baseName, "test.php") {
+	if strings.HasSuffix(baseName, "test.php") || strings.HasSuffix(baseName, "spec.php") {
 		return true
 	}
 

--- a/internal/engine/php/php_runner_test.go
+++ b/internal/engine/php/php_runner_test.go
@@ -948,20 +948,35 @@ class Calculator {
 	}
 }
 `
-	// Create a temporary file with Test.php suffix
-	tmpDir := t.TempDir()
-	tmpFile := tmpDir + "/CalculatorTest.php"
-
-	err := os.WriteFile(tmpFile, []byte(phpSource), 0644)
-	if err != nil {
-		t.Fatalf("failed to create test file: %v", err)
+	tests := []struct {
+		filename string
+		expected bool
+	}{
+		{"CalculatorTest.php", true},
+		{"CalculatorSpec.php", true},
+		{"Calculator.spec.php", true},
+		{"CALCULATORSPEC.PHP", true},
+		{"Inspector.php", false},
+		{"Calculator.php", false},
 	}
 
 	runner := &PhpRunner{}
-	file, err := runner.Parse(tmpFile)
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := tmpDir + "/" + tt.filename
 
-	assert.Nil(t, err, "Expected no error")
-	assert.True(t, file.IsTest, "Expected file to be detected as test (Test.php suffix)")
+			err := os.WriteFile(tmpFile, []byte(phpSource), 0644)
+			if err != nil {
+				t.Fatalf("failed to create test file: %v", err)
+			}
+
+			file, err := runner.Parse(tmpFile)
+
+			assert.Nil(t, err, "Expected no error")
+			assert.Equal(t, tt.expected, file.IsTest, "Expected IsTest to be %v for %s", tt.expected, tt.filename)
+		})
+	}
 }
 
 func TestPhpRunner_IsTest_ByInheritance(t *testing.T) {


### PR DESCRIPTION
Hello,

Thanks for your great project. I'm currently in the process of replacing PHPMetrics with AST Metrics and it looks really great!
However, I was a bit frustrated by the inability to configure the pattern to identify PHP test files. I believe it could be someday, but since my Go skills are a bit rusty, I preferred to add the missing case.

In our project, we use PHPSpec and Kahlan. Both default test files end with `/.?spec.php/i`:
- https://kahlan.github.io/docs/getting-started.html
- https://phpspec.net/en/stable/cookbook/configuration.html#spec-and-source-locations

I hope you don't mind adding this case as a valid test file identifier.

I tested locally on my codebase and it's great to see data showing up:

<img width="1507" height="531" alt="image" src="https://github.com/user-attachments/assets/6c6a6079-b79f-4bcd-b68d-e0fcee55b960" />

Thank you!