### PR TITLE
fix: bring dependency resolution is the same for all languages

### DIFF
--- a/internal/analyzer/aggregator.go
+++ b/internal/analyzer/aggregator.go
@@ -11,6 +11,12 @@ import (
 	"github.com/ast-metrics/ast-metrics/internal/analyzer/classifier"
 	requirement "github.com/ast-metrics/ast-metrics/internal/analyzer/requirement"
 	engine "github.com/ast-metrics/ast-metrics/internal/engine"
+	csharpdeps "github.com/ast-metrics/ast-metrics/internal/engine/csharp/deps"
+	golangdeps "github.com/ast-metrics/ast-metrics/internal/engine/golang/deps"
+	javadeps "github.com/ast-metrics/ast-metrics/internal/engine/java/deps"
+	pythondeps "github.com/ast-metrics/ast-metrics/internal/engine/python/deps"
+	rustdeps "github.com/ast-metrics/ast-metrics/internal/engine/rust/deps"
+	typescriptdeps "github.com/ast-metrics/ast-metrics/internal/engine/typescript/deps"
 	Scm "github.com/ast-metrics/ast-metrics/internal/scm"
 	pb "github.com/ast-metrics/ast-metrics/pb"
 )
@@ -99,6 +105,7 @@ type Aggregated struct {
 	TopCommitters                           []TopCommitter
 	ResultOfGitAnalysis                     []ResultOfGitAnalysis
 	PackageRelations                        map[string]map[string]int // counter of dependencies. Ex: A -> B -> 2
+	FileDependencies                        FileDependencyGraph
 	Graph                                   *pb.Graph
 	ExternalNodes                           map[string]bool // node IDs that are external (not from project source)
 	Community                               *CommunityMetrics
@@ -154,6 +161,18 @@ func NewAggregator(files []*pb.File, gitSummaries []ResultOfGitAnalysis) *Aggreg
 		gitSummaries: gitSummaries,
 	}
 	// Register default analyzers
+	// One resolver per language: an import means something different in each,
+	// and each is consulted only for the files it owns. They live in leaf
+	// packages beside their engine rather than inside it, so that an engine
+	// test may keep importing this package.
+	a.WithAggregateAnalyzer(NewFileDependencyAnalyzer(
+		typescriptdeps.NewFileDependencyResolver(),
+		golangdeps.NewFileDependencyResolver(),
+		javadeps.NewFileDependencyResolver(),
+		csharpdeps.NewFileDependencyResolver(),
+		rustdeps.NewFileDependencyResolver(),
+		pythondeps.NewFileDependencyResolver(),
+	))
 	a.WithAggregateAnalyzer(NewGraphAggregator())
 	// Run community detection after graph is built
 	a.WithAggregateAnalyzer(NewCommunityAggregator())

--- a/internal/analyzer/file_dependency_analyzer.go
+++ b/internal/analyzer/file_dependency_analyzer.go
@@ -1,0 +1,172 @@
+package analyzer
+
+import (
+	"sort"
+
+	"github.com/ast-metrics/ast-metrics/internal/engine"
+	"github.com/ast-metrics/ast-metrics/internal/engine/dependency"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// FileDependencyGraph is the project-level view of dependencies between
+// analyzed files. Import syntax remains in the AST; this graph stores the
+// result of resolving those imports against the other files in the scope.
+type FileDependencyGraph struct {
+	Efferent map[string][]string
+	Afferent map[string][]string
+}
+
+// FileDependencyAnalyzer resolves AST dependencies to analyzed files. This is
+// a semantic analysis step: reporters only project the resulting graph into
+// their output format.
+type FileDependencyAnalyzer struct {
+	resolvers []dependency.Resolver
+}
+
+func NewFileDependencyAnalyzer(resolvers ...dependency.Resolver) *FileDependencyAnalyzer {
+	return &FileDependencyAnalyzer{resolvers: resolvers}
+}
+
+func (a *FileDependencyAnalyzer) Calculate(aggregate *Aggregated) {
+	if aggregate == nil {
+		return
+	}
+	aggregate.FileDependencies = resolveFileDependencies(aggregate.ConcernedFiles, a.resolvers...)
+}
+
+// uniqueFileIndex deliberately leaves ambiguous names unresolved. Choosing the
+// first class encountered would make the graph depend on goroutine scheduling
+// because aggregate file order is not stable.
+//
+// Names are qualified by the language that declares them. Without that, a Rust
+// `User` and a Java `User` are the same key, and a polyglot repository loses
+// the edges of both: two languages that cannot import each other would still
+// make each other's names ambiguous.
+type uniqueFileIndex struct {
+	paths     map[nameInLanguage]string
+	ambiguous map[nameInLanguage]struct{}
+}
+
+type nameInLanguage struct {
+	language string
+	name     string
+}
+
+func newUniqueFileIndex() *uniqueFileIndex {
+	return &uniqueFileIndex{
+		paths:     make(map[nameInLanguage]string),
+		ambiguous: make(map[nameInLanguage]struct{}),
+	}
+}
+
+func (index *uniqueFileIndex) add(language, name, path string) {
+	if name == "" || path == "" {
+		return
+	}
+	key := nameInLanguage{language: language, name: name}
+	if _, ambiguous := index.ambiguous[key]; ambiguous {
+		return
+	}
+	if existing, found := index.paths[key]; found {
+		if existing != path {
+			delete(index.paths, key)
+			index.ambiguous[key] = struct{}{}
+		}
+		return
+	}
+	index.paths[key] = path
+}
+
+func (index *uniqueFileIndex) get(language, name string) string {
+	return index.paths[nameInLanguage{language: language, name: name}]
+}
+
+func resolveFileDependencies(files []*pb.File, resolvers ...dependency.Resolver) FileDependencyGraph {
+	graph := FileDependencyGraph{
+		Efferent: make(map[string][]string),
+		Afferent: make(map[string][]string),
+	}
+
+	analyzedPaths := make(map[string]struct{}, len(files))
+	classToFile := newUniqueFileIndex()
+	for _, file := range files {
+		if file == nil || file.GetPath() == "" {
+			continue
+		}
+		analyzedPaths[file.GetPath()] = struct{}{}
+		if file.Stmts == nil {
+			continue
+		}
+		language := file.GetProgrammingLanguage()
+		for _, class := range engine.GetClassesInFile(file) {
+			if class == nil || class.Name == nil {
+				continue
+			}
+			classToFile.add(language, class.Name.GetQualified(), file.Path)
+			classToFile.add(language, class.Name.GetShort(), file.Path)
+		}
+	}
+
+	scopedResolvers := make([]dependency.ScopedResolver, 0, len(resolvers))
+	for _, resolver := range resolvers {
+		if resolver != nil {
+			if scoped := resolver.ForFiles(files); scoped != nil {
+				scopedResolvers = append(scopedResolvers, scoped)
+			}
+		}
+	}
+
+	edges := make(map[string]map[string]struct{})
+	for _, file := range files {
+		if file == nil || file.GetPath() == "" || file.Stmts == nil {
+			continue
+		}
+		for _, external := range engine.GetDependenciesInFile(file) {
+			if external == nil {
+				continue
+			}
+
+			var targets []string
+			handled := false
+			for _, resolver := range scopedResolvers {
+				targets, handled = resolver.Resolve(file, external)
+				if handled {
+					break
+				}
+			}
+			if !handled {
+				language := file.GetProgrammingLanguage()
+				target := classToFile.get(language, external.GetNamespace())
+				if target == "" {
+					target = classToFile.get(language, external.GetClassName())
+				}
+				targets = []string{target}
+			}
+
+			for _, target := range targets {
+				if _, analyzed := analyzedPaths[target]; !analyzed || target == file.Path {
+					continue
+				}
+				if edges[file.Path] == nil {
+					edges[file.Path] = make(map[string]struct{})
+				}
+				edges[file.Path][target] = struct{}{}
+			}
+		}
+	}
+
+	for source, targets := range edges {
+		for target := range targets {
+			graph.Efferent[source] = append(graph.Efferent[source], target)
+			graph.Afferent[target] = append(graph.Afferent[target], source)
+		}
+	}
+	for source := range graph.Efferent {
+		sort.Strings(graph.Efferent[source])
+	}
+	for target := range graph.Afferent {
+		sort.Strings(graph.Afferent[target])
+	}
+
+	return graph
+}

--- a/internal/analyzer/file_dependency_analyzer_test.go
+++ b/internal/analyzer/file_dependency_analyzer_test.go
@@ -1,0 +1,202 @@
+package analyzer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ast-metrics/ast-metrics/internal/engine/dependency"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+func fileWithDependency(path, language, namespace, className string) *pb.File {
+	dependency := &pb.StmtExternalDependency{Namespace: namespace, ClassName: className}
+	return &pb.File{
+		Path:                path,
+		ProgrammingLanguage: language,
+		Stmts: &pb.Stmts{
+			StmtExternalDependencies: []*pb.StmtExternalDependency{dependency},
+		},
+	}
+}
+
+func emptyFile(path, language string) *pb.File {
+	return &pb.File{Path: path, ProgrammingLanguage: language, Stmts: &pb.Stmts{}}
+}
+
+type stubResolverFactory struct {
+	targetPaths []string
+	handled     bool
+}
+
+func (resolver stubResolverFactory) ForFiles([]*pb.File) dependency.ScopedResolver {
+	return resolver
+}
+
+func (resolver stubResolverFactory) Resolve(*pb.File, *pb.StmtExternalDependency) ([]string, bool) {
+	return resolver.targetPaths, resolver.handled
+}
+
+func TestFileDependencyAnalyzerDelegatesResolution(t *testing.T) {
+	source := fileWithDependency("/tmp/project/source.go", "Golang", "", "Target")
+	target := &pb.File{
+		Path:  "/tmp/project/target.go",
+		Stmts: &pb.Stmts{StmtClass: []*pb.StmtClass{{Name: &pb.Name{Short: "Target"}}}},
+	}
+	sibling := &pb.File{Path: "/tmp/project/sibling.go", Stmts: &pb.Stmts{}}
+
+	tests := []struct {
+		name     string
+		resolver stubResolverFactory
+		want     []string
+	}{
+		{
+			name:     "resolver returns a target",
+			resolver: stubResolverFactory{targetPaths: []string{target.Path}, handled: true},
+			want:     []string{target.Path},
+		},
+		{
+			name:     "an import naming a package depends on all of its files",
+			resolver: stubResolverFactory{targetPaths: []string{sibling.Path, target.Path}, handled: true},
+			want:     []string{sibling.Path, target.Path},
+		},
+		{
+			name:     "handled unresolved dependency does not fall back to a symbol",
+			resolver: stubResolverFactory{handled: true},
+		},
+		{
+			name:     "resolver cannot create an edge outside the analysis scope",
+			resolver: stubResolverFactory{targetPaths: []string{"/outside/project.go"}, handled: true},
+		},
+		{
+			name:     "targets outside the scope are dropped, the others kept",
+			resolver: stubResolverFactory{targetPaths: []string{"/outside/project.go", target.Path}, handled: true},
+			want:     []string{target.Path},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			graph := resolveFileDependencies([]*pb.File{source, target, sibling}, test.resolver)
+			if got := graph.Efferent[source.Path]; !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("expected dependencies %v, got %v", test.want, got)
+			}
+		})
+	}
+}
+
+// classInFile builds a file declaring one class, for the name-matching
+// fallback that serves the languages with no resolver of their own.
+func classInFile(path, language, short, qualified string) *pb.File {
+	return &pb.File{
+		Path:                path,
+		ProgrammingLanguage: language,
+		Stmts: &pb.Stmts{StmtClass: []*pb.StmtClass{{
+			Name: &pb.Name{Short: short, Qualified: qualified},
+		}}},
+	}
+}
+
+func TestFileDependencyAnalyzerLeavesAmbiguousClassNamesUnresolved(t *testing.T) {
+	source := fileWithDependency("/tmp/project/a.example", "Example", "", "Shared")
+	targetA := classInFile("/tmp/project/a/shared.example", "Example", "Shared", "a.Shared")
+	targetB := classInFile("/tmp/project/b/shared.example", "Example", "Shared", "b.Shared")
+
+	for _, files := range [][]*pb.File{
+		{source, targetA, targetB},
+		{source, targetB, targetA},
+	} {
+		graph := resolveFileDependencies(files)
+		if got := graph.Efferent[source.Path]; len(got) != 0 {
+			t.Fatalf("expected ambiguous class name to stay unresolved, got %v", got)
+		}
+	}
+}
+
+// Two languages cannot import each other, so a name declared in both is not
+// ambiguous. Sharing one index between them used to drop the edges of both.
+func TestFileDependencyAnalyzerKeepsNamesOfDifferentLanguagesApart(t *testing.T) {
+	source := fileWithDependency("/tmp/project/a.example", "Example", "", "User")
+	target := classInFile("/tmp/project/user.example", "Example", "User", "a.User")
+	homonym := classInFile("/tmp/project/user.other", "Other", "User", "b.User")
+
+	graph := resolveFileDependencies([]*pb.File{source, target, homonym})
+
+	if got := graph.Efferent[source.Path]; !reflect.DeepEqual(got, []string{target.Path}) {
+		t.Fatalf("expected the edge to survive a homonym in another language, got %v", got)
+	}
+}
+
+func TestFileDependencyAnalyzerStillResolvesClassDependencies(t *testing.T) {
+	source := fileWithDependency("/tmp/project/a.example", "Example", "", "Bar")
+	target := classInFile("/tmp/project/b.example", "Example", "Bar", "pkg\\Bar")
+	aggregate := &Aggregated{ConcernedFiles: []*pb.File{source, target}}
+
+	NewFileDependencyAnalyzer().Calculate(aggregate)
+
+	if got := aggregate.FileDependencies.Efferent[source.Path]; !reflect.DeepEqual(got, []string{target.Path}) {
+		t.Fatalf("expected class dependency on %s, got %v", target.Path, got)
+	}
+}
+
+func TestFileDependencyAnalyzerDeduplicatesAndSortsEdges(t *testing.T) {
+	source := &pb.File{
+		Path:                "/tmp/project/source.example",
+		ProgrammingLanguage: "Example",
+		Stmts: &pb.Stmts{StmtExternalDependencies: []*pb.StmtExternalDependency{
+			{ClassName: "Zulu"},
+			{ClassName: "Alpha"},
+			{ClassName: "Zulu"},
+		}},
+	}
+	alpha := classInFile("/tmp/project/alpha.example", "Example", "Alpha", "")
+	zulu := classInFile("/tmp/project/zulu.example", "Example", "Zulu", "")
+
+	graph := resolveFileDependencies([]*pb.File{source, zulu, alpha})
+
+	want := []string{alpha.Path, zulu.Path}
+	if got := graph.Efferent[source.Path]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected sorted unique edges %v, got %v", want, got)
+	}
+}
+
+func TestFileDependencyAnalyzerRespectsAggregationScopes(t *testing.T) {
+	source := fileWithDependency("/tmp/project/src/source.example", "Example", "external", "Missing")
+	target := emptyFile("/tmp/project/src/target.example", "Example")
+	otherLanguage := emptyFile("/tmp/project/src/helper.go", "Golang")
+	otherDirectory := emptyFile("/tmp/project/lib/other.example", "Example")
+	aggregator := NewAggregator([]*pb.File{source, target, otherLanguage, otherDirectory}, nil)
+	aggregator.WithAnalyzedPaths([]string{"/tmp/project/src", "/tmp/project/lib"})
+	aggregator.WithAggregateAnalyzer(NewFileDependencyAnalyzer(stubResolverFactory{
+		targetPaths: []string{target.Path},
+		handled:     true,
+	}))
+
+	project := aggregator.Aggregates()
+
+	assertEdge := func(name string, aggregate Aggregated) {
+		t.Helper()
+		if got := aggregate.FileDependencies.Efferent[source.Path]; !reflect.DeepEqual(got, []string{target.Path}) {
+			t.Fatalf("expected %s scope to contain the resolved edge, got %v", name, got)
+		}
+	}
+	assertEdge("combined", project.Combined)
+	assertEdge("language", project.ByProgrammingLanguage["Example"])
+	assertEdge("directory", project.ByDirectory["/tmp/project/src"])
+
+	if got := project.ByProgrammingLanguage["Golang"].FileDependencies.Efferent; len(got) != 0 {
+		t.Fatalf("expected Golang scope to exclude other-language edges, got %v", got)
+	}
+	if got := project.ByDirectory["/tmp/project/lib"].FileDependencies.Efferent; len(got) != 0 {
+		t.Fatalf("expected unrelated directory scope to exclude the edge, got %v", got)
+	}
+}
+
+func TestFileDependencyAnalyzerAcceptsNilAndEmptyInputs(t *testing.T) {
+	NewFileDependencyAnalyzer().Calculate(nil)
+
+	aggregate := &Aggregated{ConcernedFiles: []*pb.File{nil, {}}}
+	NewFileDependencyAnalyzer().Calculate(aggregate)
+	if aggregate.FileDependencies.Efferent == nil || aggregate.FileDependencies.Afferent == nil {
+		t.Fatal("expected initialized empty dependency maps")
+	}
+}

--- a/internal/engine/conformance/dependency_conformance_test.go
+++ b/internal/engine/conformance/dependency_conformance_test.go
@@ -1,0 +1,439 @@
+// Package conformance also checks that a dependency between two files is
+// found in every supported language.
+//
+// Unlike complexity or volume, this is not a number that must agree across
+// languages: an import means a genuinely different thing in each of them. A Go
+// import names a directory, a Java import names a type, a C# using names a
+// namespace, a Rust use names a module and a Python import names either a
+// module or an object inside one. What must hold everywhere is the outcome:
+// when a file reads another file of the project, the graph says so, and when
+// two candidates share a name, the one the language would pick is the one that
+// wins.
+//
+// The fixtures are written to disk rather than kept in memory, because that is
+// where the answers are: go.mod carries the module path, Cargo.toml the crate
+// name, and the __init__.py chain the boundary of a Python package.
+package conformance
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/ast-metrics/ast-metrics/internal/analyzer"
+	"github.com/ast-metrics/ast-metrics/internal/configuration"
+	"github.com/ast-metrics/ast-metrics/internal/engine"
+	"github.com/ast-metrics/ast-metrics/internal/engine/csharp"
+	"github.com/ast-metrics/ast-metrics/internal/engine/golang"
+	"github.com/ast-metrics/ast-metrics/internal/engine/java"
+	"github.com/ast-metrics/ast-metrics/internal/engine/php"
+	"github.com/ast-metrics/ast-metrics/internal/engine/python"
+	"github.com/ast-metrics/ast-metrics/internal/engine/rust"
+	"github.com/ast-metrics/ast-metrics/internal/engine/typescript"
+)
+
+type dependencyScenario struct {
+	name string
+	// why explains what the case proves, so a failure is readable.
+	why string
+	// files maps a path relative to the project root to its content.
+	files map[string]string
+	// edges maps a source file to the files it must depend on, both relative
+	// to the project root. A file absent from the map must have no dependency.
+	edges map[string][]string
+}
+
+// ---------------------------------------------------------------------------
+// Go: an import names a package, which is a directory under the module path
+// ---------------------------------------------------------------------------
+
+var goScenarios = []dependencyScenario{
+	{
+		name: "import path built from the module path",
+		why:  "the specifier is example.com/demo/internal/model, which no type name can ever match",
+		files: map[string]string{
+			"go.mod":                  "module example.com/demo\n\ngo 1.21\n",
+			"internal/model/user.go":  "package model\n\ntype User struct{ Name string }\n",
+			"internal/store/store.go": "package store\n\nimport \"example.com/demo/internal/model\"\n\ntype Store struct{ Users []model.User }\n",
+			"cmd/app/main.go":         "package main\n\nimport (\n\t\"fmt\"\n\t\"example.com/demo/internal/store\"\n)\n\nfunc main() { fmt.Println(store.Store{}) }\n",
+		},
+		edges: map[string][]string{
+			"internal/store/store.go": {"internal/model/user.go"},
+			// "fmt" is outside the analyzed sources and must not become an edge.
+			"cmd/app/main.go": {"internal/store/store.go"},
+		},
+	},
+	{
+		name: "a package is every file of its directory",
+		why:  "Go compiles a directory as one unit, so importing it depends on all of it",
+		files: map[string]string{
+			"go.mod":            "module example.com/demo\n",
+			"pkg/data/user.go":  "package data\n\ntype User struct{}\n",
+			"pkg/data/order.go": "package data\n\ntype Order struct{}\n",
+			"app.go":            "package main\n\nimport \"example.com/demo/pkg/data\"\n\nvar u = data.User{}\n",
+		},
+		edges: map[string][]string{
+			"app.go": {"pkg/data/order.go", "pkg/data/user.go"},
+		},
+	},
+	{
+		name: "two modules in one repository",
+		why:  "each import path is read against the go.mod nearest to the importing file",
+		files: map[string]string{
+			"a/go.mod":         "module example.com/a\n",
+			"a/thing/thing.go": "package thing\n\ntype Thing struct{}\n",
+			"a/main.go":        "package main\n\nimport \"example.com/a/thing\"\n\nvar t = thing.Thing{}\n",
+			"b/go.mod":         "module example.com/b\n",
+			"b/thing/thing.go": "package thing\n\ntype Thing struct{}\n",
+			"b/main.go":        "package main\n\nimport \"example.com/b/thing\"\n\nvar t = thing.Thing{}\n",
+		},
+		edges: map[string][]string{
+			"a/main.go": {"a/thing/thing.go"},
+			"b/main.go": {"b/thing/thing.go"},
+		},
+	},
+}
+
+// ---------------------------------------------------------------------------
+// Java: an import names a type by its fully qualified name
+// ---------------------------------------------------------------------------
+
+var javaScenarios = []dependencyScenario{
+	{
+		name: "the package tells two types of the same name apart",
+		why:  "com.demo.a.Item and com.demo.b.Item are two types; matching on Item alone can only guess",
+		files: map[string]string{
+			"src/com/demo/a/Item.java": "package com.demo.a;\npublic class Item { public int id; }\n",
+			"src/com/demo/b/Item.java": "package com.demo.b;\npublic class Item { public String label; }\n",
+			"src/com/demo/App.java":    "package com.demo;\nimport com.demo.a.Item;\npublic class App { Item it = new Item(); }\n",
+		},
+		edges: map[string][]string{
+			"src/com/demo/App.java": {"src/com/demo/a/Item.java"},
+		},
+	},
+	{
+		name: "a wildcard import depends on the whole package",
+		why:  "import com.demo.model.* names no type, so every file of the package answers",
+		files: map[string]string{
+			"src/com/demo/model/User.java":  "package com.demo.model;\npublic class User {}\n",
+			"src/com/demo/model/Order.java": "package com.demo.model;\npublic class Order {}\n",
+			"src/com/demo/App.java":         "package com.demo;\nimport com.demo.model.*;\npublic class App { User u; }\n",
+		},
+		edges: map[string][]string{
+			"src/com/demo/App.java": {"src/com/demo/model/Order.java", "src/com/demo/model/User.java"},
+		},
+	},
+	{
+		name: "a static import names a member of a type",
+		why:  "import static com.demo.util.Maths.add splits one level below the package",
+		files: map[string]string{
+			"src/com/demo/util/Maths.java": "package com.demo.util;\npublic class Maths { public static int add(int a, int b) { return a + b; } }\n",
+			"src/com/demo/App.java":        "package com.demo;\nimport static com.demo.util.Maths.add;\npublic class App { int r = add(1, 2); }\n",
+		},
+		edges: map[string][]string{
+			"src/com/demo/App.java": {"src/com/demo/util/Maths.java"},
+		},
+	},
+	{
+		name: "the JDK is not part of the project",
+		why:  "java.util.List must stay unresolved rather than bind to a class of the project called List",
+		files: map[string]string{
+			"src/com/demo/List.java": "package com.demo;\npublic class List {}\n",
+			"src/com/demo/App.java":  "package com.demo;\nimport java.util.List;\npublic class App { List<String> l; }\n",
+		},
+		edges: map[string][]string{},
+	},
+}
+
+// ---------------------------------------------------------------------------
+// C#: a using names a namespace, which files declare wherever they like
+// ---------------------------------------------------------------------------
+
+var csharpScenarios = []dependencyScenario{
+	{
+		name: "a using resolves to the files declaring the namespace",
+		why:  "no class is named after a namespace, so name matching finds nothing at all in C#",
+		files: map[string]string{
+			"Model/User.cs":  "namespace Demo.Model;\n\npublic class User { public string Name { get; set; } }\n",
+			"Model/Order.cs": "namespace Demo.Model;\n\npublic class Order { public int Id { get; set; } }\n",
+			"Store/Store.cs": "using Demo.Model;\n\nnamespace Demo.Store;\n\npublic class Store { public User Find() => new User(); }\n",
+		},
+		edges: map[string][]string{
+			"Store/Store.cs": {"Model/Order.cs", "Model/User.cs"},
+		},
+	},
+	{
+		name: "a nested namespace is not pulled in by its parent",
+		why:  "C# does not import namespaces transitively",
+		files: map[string]string{
+			"Model/User.cs":            "namespace Demo.Model;\n\npublic class User {}\n",
+			"Model/Internal/Detail.cs": "namespace Demo.Model.Internal;\n\npublic class Detail {}\n",
+			"App.cs":                   "using Demo.Model;\n\nnamespace Demo;\n\npublic class App { User u; }\n",
+		},
+		edges: map[string][]string{
+			"App.cs": {"Model/User.cs"},
+		},
+	},
+	{
+		name: "the base class library is not part of the project",
+		why:  "using System must stay unresolved",
+		files: map[string]string{
+			"App.cs": "using System;\n\nnamespace Demo;\n\npublic class App { public void Run() { Console.WriteLine(\"x\"); } }\n",
+		},
+		edges: map[string][]string{},
+	},
+}
+
+// ---------------------------------------------------------------------------
+// Rust: a use names a module of the crate's module tree
+// ---------------------------------------------------------------------------
+
+var rustScenarios = []dependencyScenario{
+	{
+		name: "crate, self and super anchor a path",
+		why:  "the same module is spelled three ways depending on where the file sits",
+		files: map[string]string{
+			"Cargo.toml":         "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+			"src/main.rs":        "mod model;\nmod store;\n\nfn main() {}\n",
+			"src/model.rs":       "pub struct User { pub name: String }\n",
+			"src/store/mod.rs":   "mod inner;\nuse crate::model::User;\n\npub struct Store { pub users: Vec<User> }\n",
+			"src/store/inner.rs": "use super::Store;\n\npub fn take(_s: Store) {}\n",
+		},
+		edges: map[string][]string{
+			"src/main.rs":        {"src/model.rs", "src/store/mod.rs"},
+			"src/store/mod.rs":   {"src/model.rs", "src/store/inner.rs"},
+			"src/store/inner.rs": {"src/store/mod.rs"},
+		},
+	},
+	{
+		name: "a module written as a file or as a directory is the same module",
+		why:  "src/a.rs and src/a/mod.rs are both the module a",
+		files: map[string]string{
+			"Cargo.toml":      "[package]\nname = \"demo\"\n",
+			"src/lib.rs":      "mod alpha;\nmod beta;\n",
+			"src/alpha.rs":    "pub struct Alpha;\n",
+			"src/beta/mod.rs": "use crate::alpha::Alpha;\n\npub struct Beta(pub Alpha);\n",
+		},
+		edges: map[string][]string{
+			"src/lib.rs":      {"src/alpha.rs", "src/beta/mod.rs"},
+			"src/beta/mod.rs": {"src/alpha.rs"},
+		},
+	},
+	{
+		name: "another crate of the workspace",
+		why:  "a leading crate name is read against the Cargo.toml that declares it",
+		files: map[string]string{
+			"core/Cargo.toml": "[package]\nname = \"demo-core\"\n",
+			"core/src/lib.rs": "pub struct Config;\n",
+			"app/Cargo.toml":  "[package]\nname = \"demo-app\"\n",
+			"app/src/main.rs": "use demo_core::Config;\n\nfn main() { let _c = Config; }\n",
+		},
+		edges: map[string][]string{
+			"app/src/main.rs": {"core/src/lib.rs"},
+		},
+	},
+	{
+		name: "an external crate is not part of the project",
+		why:  "use std::fmt::Display must stay unresolved even next to a module called fmt",
+		files: map[string]string{
+			"Cargo.toml": "[package]\nname = \"demo\"\n",
+			"src/lib.rs": "use std::fmt::Display;\n\npub struct Thing;\n",
+		},
+		edges: map[string][]string{},
+	},
+}
+
+// ---------------------------------------------------------------------------
+// Python: an import names a module, found through the __init__.py chain
+// ---------------------------------------------------------------------------
+
+var pythonScenarios = []dependencyScenario{
+	{
+		name: "absolute and relative imports reach the same module",
+		why:  "the leading dots of ..model count packages upwards from the importing file",
+		files: map[string]string{
+			"pkg/__init__.py":     "",
+			"pkg/sub/__init__.py": "",
+			"pkg/model.py":        "class User:\n    pass\n",
+			"pkg/sub/store.py":    "from ..model import User\n\nclass Store:\n    def add(self, u: User):\n        return u\n",
+			"app.py":              "from pkg.sub.store import Store\nimport pkg.model\n\ndef main():\n    return Store()\n",
+		},
+		edges: map[string][]string{
+			"pkg/sub/store.py": {"pkg/model.py"},
+			"app.py":           {"pkg/model.py", "pkg/sub/store.py"},
+		},
+	},
+	{
+		name: "a relative import climbing one package too far",
+		why:  "two modules called model, only the one the dots point at is the target",
+		files: map[string]string{
+			"pkg/__init__.py":     "",
+			"pkg/model.py":        "class Outer:\n    pass\n",
+			"pkg/sub/__init__.py": "",
+			"pkg/sub/model.py":    "class Inner:\n    pass\n",
+			"pkg/sub/store.py":    "from .model import Inner\n\nclass Store:\n    pass\n",
+		},
+		edges: map[string][]string{
+			"pkg/sub/store.py": {"pkg/sub/model.py"},
+		},
+	},
+	{
+		name: "from a package import a submodule",
+		why:  "in `from pkg import model` the name is a module, not an object of the package",
+		files: map[string]string{
+			"pkg/__init__.py": "",
+			"pkg/model.py":    "class User:\n    pass\n",
+			"app.py":          "from pkg import model\n\ndef main():\n    return model.User()\n",
+		},
+		edges: map[string][]string{
+			"app.py": {"pkg/model.py"},
+		},
+	},
+	{
+		name: "a module inside a package is not reachable by its last segment",
+		why:  "helpers.json is not what `import json` names, so the standard library stays unresolved",
+		files: map[string]string{
+			"helpers/__init__.py": "",
+			"helpers/json.py":     "class Encoder:\n    pass\n",
+			"app.py":              "import json\n\ndef main():\n    return json.dumps({})\n",
+		},
+		edges: map[string][]string{},
+	},
+}
+
+// ---------------------------------------------------------------------------
+// PHP and TypeScript
+// ---------------------------------------------------------------------------
+
+var phpScenarios = []dependencyScenario{
+	{
+		name: "a use names a class by its fully qualified name",
+		why:  "the namespace makes the name unique, which is what PSR-4 maps onto a path",
+		files: map[string]string{
+			"src/Model/User.php":  "<?php\nnamespace App\\Model;\n\nclass User { public string $name = \"\"; }\n",
+			"src/Store/Store.php": "<?php\nnamespace App\\Store;\n\nuse App\\Model\\User;\n\nclass Store { public function find(): User { return new User(); } }\n",
+			"src/App.php":         "<?php\nnamespace App;\n\nuse App\\Store\\Store;\n\nclass App { public function run(): Store { return new Store(); } }\n",
+		},
+		edges: map[string][]string{
+			"src/Store/Store.php": {"src/Model/User.php"},
+			"src/App.php":         {"src/Store/Store.php"},
+		},
+	},
+}
+
+var typescriptScenarios = []dependencyScenario{
+	{
+		name: "relative specifiers, directory index and extension substitution",
+		why:  "./store is the index of a directory, and ./model.js is written for the emitted file",
+		files: map[string]string{
+			"src/model.ts":       "export class User { constructor(public name: string) {} }\n",
+			"src/store/index.ts": "import { User } from \"../model\";\n\nexport class Store { users: User[] = []; }\n",
+			"src/app.ts":         "import { Store } from \"./store\";\nimport { User } from \"./model.js\";\n\nexport class App { store = new Store(); u?: User; }\n",
+		},
+		edges: map[string][]string{
+			"src/store/index.ts": {"src/model.ts"},
+			"src/app.ts":         {"src/model.ts", "src/store/index.ts"},
+		},
+	},
+	{
+		name: "a package import is not a file of the project",
+		why:  "a bare specifier must not bind to a class of the project carrying that name",
+		files: map[string]string{
+			"src/lodash.ts": "export class Lodash {}\n",
+			"src/app.ts":    "import lodash from \"lodash\";\n\nexport class App { l = lodash; }\n",
+		},
+		edges: map[string][]string{},
+	},
+}
+
+func TestDependencyConformance(t *testing.T) {
+	suites := []struct {
+		language  string
+		scenarios []dependencyScenario
+	}{
+		{langGo, goScenarios},
+		{langJava, javaScenarios},
+		{langCSharp, csharpScenarios},
+		{langRust, rustScenarios},
+		{langPython, pythonScenarios},
+		{langPHP, phpScenarios},
+		{langTS, typescriptScenarios},
+	}
+
+	for _, suite := range suites {
+		for _, scenario := range suite.scenarios {
+			t.Run(suite.language+"/"+scenario.name, func(t *testing.T) {
+				root := writeProject(t, scenario.files)
+				got := dependencyEdges(t, root)
+				want := scenario.edges
+				if want == nil {
+					want = map[string][]string{}
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("%s\nexpected %v\ngot      %v", scenario.why, want, got)
+				}
+			})
+		}
+	}
+}
+
+// writeProject materializes a fixture and returns its root directory.
+func writeProject(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("cannot create %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("cannot write %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+// dependencyEdges runs the whole pipeline over a directory and returns the
+// resolved graph, with every path made relative to the project root.
+func dependencyEdges(t *testing.T, root string) map[string][]string {
+	t.Helper()
+
+	config := configuration.NewConfiguration()
+	config.SetSourcesToAnalyzePath([]string{root})
+
+	parsed, err := engine.ParseFiles(config, []engine.Engine{
+		&golang.GolangRunner{}, &php.PhpRunner{}, &python.PythonRunner{},
+		&rust.RustRunner{}, &typescript.TypeScriptRunner{},
+		&java.JavaRunner{}, &csharp.CSharpRunner{},
+	})
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	project := analyzer.NewAggregator(analyzer.AnalyzeFiles(parsed, nil), nil).Aggregates()
+
+	edges := map[string][]string{}
+	for source, targets := range project.Combined.FileDependencies.Efferent {
+		if len(targets) == 0 {
+			continue
+		}
+		relative := make([]string, 0, len(targets))
+		for _, target := range targets {
+			relative = append(relative, relativeTo(t, root, target))
+		}
+		sort.Strings(relative)
+		edges[relativeTo(t, root, source)] = relative
+	}
+	return edges
+}
+
+func relativeTo(t *testing.T, root, path string) string {
+	t.Helper()
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		t.Fatalf("%s is not under %s: %v", path, root, err)
+	}
+	return filepath.ToSlash(relative)
+}

--- a/internal/engine/csharp/deps/resolver.go
+++ b/internal/engine/csharp/deps/resolver.go
@@ -1,0 +1,87 @@
+package deps
+
+import (
+	"github.com/ast-metrics/ast-metrics/internal/engine"
+	"github.com/ast-metrics/ast-metrics/internal/engine/dependency"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// Language is the value the C# engine writes in pb.File.ProgrammingLanguage.
+const Language = "C#"
+
+// FileDependencyResolver owns C# using resolution.
+//
+// C# is the one language of the set where a name says nothing about a file: a
+// namespace is declared by as many files as its author likes, in any
+// directory. A plain `using` therefore resolves to every analyzed file
+// declaring that namespace, which is the granularity the directive itself
+// carries. `using static` and alias forms name a type and resolve to the
+// single file declaring it.
+//
+// This is why matching class names, as the shared fallback does, finds nothing
+// at all in C#: a using directive names a namespace, and no class is called
+// after one.
+//
+// The namespace granularity over-approximates, and knowingly so. A file using
+// one type of a namespace of forty gets forty edges, where a Go import of a
+// package genuinely depends on all of its files. Narrowing it means knowing
+// which types the file names, which the C# AST does not record today: nothing
+// in the parsed tree lists the identifiers a file references. Until it does,
+// an edge too many is preferred to the graph C# had before, which was empty.
+type FileDependencyResolver struct{}
+
+var _ dependency.Resolver = (*FileDependencyResolver)(nil)
+
+func NewFileDependencyResolver() *FileDependencyResolver {
+	return &FileDependencyResolver{}
+}
+
+func (r *FileDependencyResolver) ForFiles(files []*pb.File) dependency.ScopedResolver {
+	namespaces := dependency.NewIndex()
+	types := dependency.NewIndex()
+
+	for _, file := range files {
+		path := file.GetPath()
+		if file == nil || path == "" || file.GetProgrammingLanguage() != Language {
+			continue
+		}
+		for _, namespace := range file.GetStmts().GetStmtNamespace() {
+			if name := namespace.GetName(); name != nil {
+				namespaces.Add(dependency.QualifiedOrShort(name), path)
+			}
+		}
+		for _, class := range engine.GetClassesInFile(file) {
+			if name := class.GetName(); name != nil {
+				types.Add(dependency.QualifiedOrShort(name), path)
+			}
+		}
+	}
+	return &scopedFileDependencyResolver{namespaces: namespaces, types: types}
+}
+
+type scopedFileDependencyResolver struct {
+	namespaces *dependency.Index
+	types      *dependency.Index
+}
+
+var _ dependency.ScopedResolver = (*scopedFileDependencyResolver)(nil)
+
+func (r *scopedFileDependencyResolver) Resolve(source *pb.File, dep *pb.StmtExternalDependency) ([]string, bool) {
+	if source == nil || dep == nil || source.GetProgrammingLanguage() != Language {
+		return nil, false
+	}
+
+	// Every dependency of a C# file is claimed, resolved or not: the BCL and
+	// the NuGet packages sit outside the analyzed scope by design.
+	target := dep.GetNamespace()
+	if target == "" {
+		return nil, true
+	}
+	// A type is looked up first: `using static Demo.Model.User` and
+	// `using U = Demo.Model.User` both name one, and a namespace never shares
+	// its name with a type in the same scope.
+	if targets := r.types.Get(target); len(targets) > 0 {
+		return targets, true
+	}
+	return r.namespaces.Get(target), true
+}

--- a/internal/engine/dependency/index.go
+++ b/internal/engine/dependency/index.go
@@ -1,0 +1,78 @@
+package dependency
+
+import (
+	"sort"
+
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// QualifiedOrShort returns the name a declaration is looked up by. The
+// qualified form is the one an import spells out, and the short form is all
+// there is when a file declares no namespace.
+func QualifiedOrShort(name *pb.Name) string {
+	if qualified := name.GetQualified(); qualified != "" {
+		return qualified
+	}
+	return name.GetShort()
+}
+
+// Index maps a resolution key to the files that answer it.
+//
+// The key is whatever unit the language's import syntax names: a package
+// import path in Go, a fully qualified type in Java, a namespace in C#, a
+// module path in Python and Rust. Several files can answer one key, so the
+// index keeps them all instead of letting the last writer win: the files of a
+// Go package are equally the target of an import of that package.
+//
+// Results are sorted, which is what makes the graph reproducible. Files reach
+// the index in the order the parsers happen to finish, and that order changes
+// between two runs on the same sources.
+type Index struct {
+	entries map[string]map[string]struct{}
+}
+
+func NewIndex() *Index {
+	return &Index{entries: make(map[string]map[string]struct{})}
+}
+
+func (index *Index) Add(key, path string) {
+	if key == "" || path == "" {
+		return
+	}
+	if index.entries[key] == nil {
+		index.entries[key] = make(map[string]struct{})
+	}
+	index.entries[key][path] = struct{}{}
+}
+
+// Get returns the files registered under key, sorted.
+func (index *Index) Get(key string) []string {
+	if key == "" {
+		return nil
+	}
+	paths := index.entries[key]
+	if len(paths) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(paths))
+	for path := range paths {
+		result = append(result, path)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// GetUnambiguous returns the files registered under key only when the key
+// designates a single file. It backs the suffix lookups used when a project
+// layout hides the real root: guessing is only acceptable when there is
+// nothing to guess between.
+func (index *Index) GetUnambiguous(key string) []string {
+	if paths := index.Get(key); len(paths) == 1 {
+		return paths
+	}
+	return nil
+}
+
+func (index *Index) Has(key string) bool {
+	return len(index.entries[key]) > 0
+}

--- a/internal/engine/dependency/index_test.go
+++ b/internal/engine/dependency/index_test.go
@@ -1,0 +1,50 @@
+package dependency
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIndexKeepsEveryFileUnderAKey(t *testing.T) {
+	index := NewIndex()
+	// Insertion order is the order the parsers happen to finish in, and the
+	// index must not let it show.
+	index.Add("pkg", "/project/zulu.go")
+	index.Add("pkg", "/project/alpha.go")
+	index.Add("pkg", "/project/zulu.go")
+
+	want := []string{"/project/alpha.go", "/project/zulu.go"}
+	if got := index.Get("pkg"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestIndexIgnoresEmptyKeysAndPaths(t *testing.T) {
+	index := NewIndex()
+	index.Add("", "/project/a.go")
+	index.Add("pkg", "")
+
+	if index.Has("") || index.Has("pkg") {
+		t.Fatal("expected empty keys and paths to be ignored")
+	}
+	if got := index.Get(""); got != nil {
+		t.Fatalf("expected no result for an empty key, got %v", got)
+	}
+}
+
+func TestIndexUnambiguousLookupRefusesToChoose(t *testing.T) {
+	index := NewIndex()
+	index.Add("one", "/project/only.go")
+	index.Add("many", "/project/a.go")
+	index.Add("many", "/project/b.go")
+
+	if got := index.GetUnambiguous("one"); !reflect.DeepEqual(got, []string{"/project/only.go"}) {
+		t.Fatalf("expected the single candidate, got %v", got)
+	}
+	if got := index.GetUnambiguous("many"); got != nil {
+		t.Fatalf("expected no answer when several files match, got %v", got)
+	}
+	if got := index.GetUnambiguous("none"); got != nil {
+		t.Fatalf("expected no answer for an unknown key, got %v", got)
+	}
+}

--- a/internal/engine/dependency/resolver.go
+++ b/internal/engine/dependency/resolver.go
@@ -1,0 +1,26 @@
+// Package dependency defines the language-neutral contract used to resolve
+// AST dependencies to files from an analysis scope.
+package dependency
+
+import pb "github.com/ast-metrics/ast-metrics/pb"
+
+// Resolver creates an immutable resolver for one analysis scope. Building the
+// scope once lets language engines index candidate files without sharing state
+// between the different aggregates (project, language and directory).
+type Resolver interface {
+	ForFiles(files []*pb.File) ScopedResolver
+}
+
+// ScopedResolver resolves one AST dependency. Handled is true when the
+// resolver owns that dependency, including when it deliberately leaves an
+// external or missing target unresolved. Resolvers are consulted in order and
+// the first one returning handled wins.
+//
+// Several targets are returned because an import does not always name a file.
+// A Go import names a package, which is a directory; a Java wildcard import
+// and a C# using name a namespace. The importing file depends on every file
+// that makes up the named unit, and reporting only one of them would be an
+// arbitrary choice among equals.
+type ScopedResolver interface {
+	Resolve(source *pb.File, dependency *pb.StmtExternalDependency) (targetPaths []string, handled bool)
+}

--- a/internal/engine/golang/deps/resolver.go
+++ b/internal/engine/golang/deps/resolver.go
@@ -1,0 +1,174 @@
+package deps
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ast-metrics/ast-metrics/internal/engine/dependency"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// Language is the value the Go engine writes in pb.File.ProgrammingLanguage.
+const Language = "Golang"
+
+// FileDependencyResolver owns Go import resolution.
+//
+// A Go import names a package, and a package is a directory. Its import path
+// is the module path declared in go.mod followed by the path of the directory
+// relative to that go.mod, which is the same rule the toolchain applies. The
+// importing file therefore depends on every analyzed file of that directory:
+// they are compiled as one unit and the import statement names no symbol that
+// would let us single one of them out.
+type FileDependencyResolver struct{}
+
+var _ dependency.Resolver = (*FileDependencyResolver)(nil)
+
+func NewFileDependencyResolver() *FileDependencyResolver {
+	return &FileDependencyResolver{}
+}
+
+func (r *FileDependencyResolver) ForFiles(files []*pb.File) dependency.ScopedResolver {
+	packages := dependency.NewIndex()
+	// Directory suffixes back up the go.mod lookup: a repository analyzed from
+	// a subdirectory, or vendored sources, can put the module file out of
+	// reach. A suffix is only trusted when it designates a single package.
+	suffixes := dependency.NewIndex()
+
+	modules := newModuleCache()
+	for _, file := range files {
+		path := file.GetPath()
+		if file == nil || path == "" || file.GetProgrammingLanguage() != Language {
+			continue
+		}
+		directory := filepath.Dir(path)
+		if importPath := modules.importPathOf(directory); importPath != "" {
+			packages.Add(importPath, path)
+		}
+		for _, suffix := range directorySuffixes(directory) {
+			suffixes.Add(suffix, path)
+		}
+	}
+	return &scopedFileDependencyResolver{packages: packages, suffixes: suffixes}
+}
+
+type scopedFileDependencyResolver struct {
+	packages *dependency.Index
+	suffixes *dependency.Index
+}
+
+var _ dependency.ScopedResolver = (*scopedFileDependencyResolver)(nil)
+
+func (r *scopedFileDependencyResolver) Resolve(source *pb.File, dep *pb.StmtExternalDependency) ([]string, bool) {
+	if source == nil || dep == nil || source.GetProgrammingLanguage() != Language {
+		return nil, false
+	}
+
+	// Every dependency of a Go file is claimed, resolved or not. The standard
+	// library and third-party modules are legitimately absent from the scope,
+	// and letting "fmt" or "errors" fall through to name matching would bind
+	// the file to whichever type happens to carry that name.
+	importPath := dep.GetNamespace()
+	if importPath == "" {
+		return nil, true
+	}
+	if targets := r.packages.Get(importPath); len(targets) > 0 {
+		return targets, true
+	}
+
+	// Longest first, so "example.com/demo/internal/model" prefers a package
+	// sitting in ".../demo/internal/model" over one in ".../model". The last
+	// segment alone is never tried: matching "model" against every directory
+	// of that name would invent edges, and a one-segment import path is a
+	// standard library package, which is out of scope by definition.
+	for _, suffix := range pathSuffixes(importPath) {
+		if targets := r.suffixes.GetUnambiguous(suffix); len(targets) > 0 {
+			return targets, true
+		}
+	}
+	return nil, true
+}
+
+// pathSuffixes lists the trailing fragments of a slash-separated path, longest
+// first, down to two segments.
+func pathSuffixes(path string) []string {
+	segments := strings.Split(strings.Trim(filepath.ToSlash(path), "/"), "/")
+	suffixes := make([]string, 0, len(segments))
+	for i := 0; i+1 < len(segments); i++ {
+		suffixes = append(suffixes, strings.Join(segments[i:], "/"))
+	}
+	return suffixes
+}
+
+// directorySuffixes lists the trailing fragments of a directory path, so a
+// package can be found by the tail of its import path.
+func directorySuffixes(directory string) []string {
+	return pathSuffixes(filepath.Clean(directory))
+}
+
+// moduleCache resolves a directory to the import path of the package it holds,
+// remembering the go.mod files found on the way up. One repository can hold
+// several modules, so the lookup stops at the nearest go.mod rather than at a
+// single project-wide root.
+type moduleCache struct {
+	// modulePathByRoot maps the directory holding a go.mod to its module path,
+	// with an empty value marking a directory known to hold no readable go.mod.
+	modulePathByRoot map[string]string
+}
+
+func newModuleCache() *moduleCache {
+	return &moduleCache{modulePathByRoot: make(map[string]string)}
+}
+
+func (c *moduleCache) importPathOf(directory string) string {
+	absolute, err := filepath.Abs(directory)
+	if err != nil {
+		absolute = filepath.Clean(directory)
+	}
+
+	for current := absolute; ; {
+		if modulePath := c.modulePathAt(current); modulePath != "" {
+			relative, err := filepath.Rel(current, absolute)
+			if err != nil {
+				return ""
+			}
+			relative = filepath.ToSlash(relative)
+			if relative == "." {
+				return modulePath
+			}
+			return modulePath + "/" + relative
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return ""
+		}
+		current = parent
+	}
+}
+
+func (c *moduleCache) modulePathAt(directory string) string {
+	if modulePath, known := c.modulePathByRoot[directory]; known {
+		return modulePath
+	}
+	modulePath := ""
+	if content, err := os.ReadFile(filepath.Join(directory, "go.mod")); err == nil {
+		modulePath = modulePathIn(string(content))
+	}
+	c.modulePathByRoot[directory] = modulePath
+	return modulePath
+}
+
+// modulePathIn reads the module path out of a go.mod. Only the module
+// directive is needed, so the file is scanned rather than parsed.
+func modulePathIn(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		// Splitting on spaces keeps "modules" from passing for "module" and
+		// drops any trailing comment along the way.
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "module" {
+			continue
+		}
+		return strings.Trim(fields[1], `"`)
+	}
+	return ""
+}

--- a/internal/engine/golang/deps/resolver_test.go
+++ b/internal/engine/golang/deps/resolver_test.go
@@ -1,0 +1,73 @@
+package deps
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestModulePathIn(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "plain declaration",
+			content: "module example.com/demo\n\ngo 1.21\n",
+			want:    "example.com/demo",
+		},
+		{
+			name:    "leading blank lines and comments",
+			content: "// a comment\n\n   module   example.com/demo   \n",
+			want:    "example.com/demo",
+		},
+		{
+			name:    "trailing comment",
+			content: "module example.com/demo // the main module\n",
+			want:    "example.com/demo",
+		},
+		{
+			name:    "quoted path",
+			content: "module \"example.com/demo\"\n",
+			want:    "example.com/demo",
+		},
+		{
+			// The require block also holds lines starting with a module path,
+			// but the directive itself comes first.
+			name:    "require block does not win",
+			content: "module example.com/demo\n\nrequire (\n\tmodule.example/other v1.0.0\n)\n",
+			want:    "example.com/demo",
+		},
+		{
+			name:    "no module directive",
+			content: "go 1.21\n",
+			want:    "",
+		},
+		{
+			// "modules" is not "module": a prefix match alone would take it.
+			name:    "a longer word is not the directive",
+			content: "modules example.com/demo\n",
+			want:    "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := modulePathIn(test.content); got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func TestPathSuffixesStopsBeforeTheLastSegment(t *testing.T) {
+	want := []string{"example.com/demo/internal/model", "demo/internal/model", "internal/model"}
+	if got := pathSuffixes("example.com/demo/internal/model"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	// A one-segment import path is a standard library package: offering
+	// "fmt" as a suffix would let it match any directory called fmt.
+	if got := pathSuffixes("fmt"); len(got) != 0 {
+		t.Fatalf("expected no suffix for a single segment, got %v", got)
+	}
+}

--- a/internal/engine/java/deps/resolver.go
+++ b/internal/engine/java/deps/resolver.go
@@ -1,0 +1,82 @@
+package deps
+
+import (
+	"github.com/ast-metrics/ast-metrics/internal/engine"
+	"github.com/ast-metrics/ast-metrics/internal/engine/dependency"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// Language is the value the Java engine writes in pb.File.ProgrammingLanguage.
+const Language = "Java"
+
+// FileDependencyResolver owns Java import resolution.
+//
+// A Java import names a type by its fully qualified name, so resolution is a
+// lookup on that name and nothing else. Matching on the simple name instead,
+// as the shared fallback does, cannot tell `com.demo.a.Item` from
+// `com.demo.b.Item`: the very case the package system exists to disambiguate.
+type FileDependencyResolver struct{}
+
+var _ dependency.Resolver = (*FileDependencyResolver)(nil)
+
+func NewFileDependencyResolver() *FileDependencyResolver {
+	return &FileDependencyResolver{}
+}
+
+func (r *FileDependencyResolver) ForFiles(files []*pb.File) dependency.ScopedResolver {
+	types := dependency.NewIndex()
+	packages := dependency.NewIndex()
+
+	for _, file := range files {
+		path := file.GetPath()
+		if file == nil || path == "" || file.GetProgrammingLanguage() != Language {
+			continue
+		}
+		for _, namespace := range file.GetStmts().GetStmtNamespace() {
+			if name := namespace.GetName(); name != nil {
+				packages.Add(dependency.QualifiedOrShort(name), path)
+			}
+		}
+		for _, class := range engine.GetClassesInFile(file) {
+			if name := class.GetName(); name != nil {
+				types.Add(dependency.QualifiedOrShort(name), path)
+			}
+		}
+	}
+	return &scopedFileDependencyResolver{types: types, packages: packages}
+}
+
+type scopedFileDependencyResolver struct {
+	types    *dependency.Index
+	packages *dependency.Index
+}
+
+var _ dependency.ScopedResolver = (*scopedFileDependencyResolver)(nil)
+
+func (r *scopedFileDependencyResolver) Resolve(source *pb.File, dep *pb.StmtExternalDependency) ([]string, bool) {
+	if source == nil || dep == nil || source.GetProgrammingLanguage() != Language {
+		return nil, false
+	}
+
+	// Every dependency of a Java file is claimed, resolved or not: the JDK and
+	// the third-party jars are legitimately outside the analyzed scope, and an
+	// unresolved `java.util.List` must not fall back to matching a project
+	// class that happens to be called List.
+	pkg, simpleName := dep.GetNamespace(), dep.GetClassName()
+
+	// `import a.b.*;` carries no type name: it depends on the whole package.
+	if simpleName == "" {
+		return r.packages.Get(pkg), true
+	}
+
+	if targets := r.types.Get(pkg + "." + simpleName); len(targets) > 0 {
+		return targets, true
+	}
+
+	// The same lookup one level up covers the two forms that name something
+	// inside a type rather than inside a package: a static import
+	// (`import static a.b.C.m;` splits into "a.b.C" and "m") and a nested type
+	// (`import a.b.Outer.Inner;`). Both are declared by the file that declares
+	// the enclosing type.
+	return r.types.Get(pkg), true
+}

--- a/internal/engine/python/deps/resolver.go
+++ b/internal/engine/python/deps/resolver.go
@@ -1,0 +1,217 @@
+package deps
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ast-metrics/ast-metrics/internal/engine/dependency"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// Language is the value the Python engine writes in pb.File.ProgrammingLanguage.
+const Language = "Python"
+
+// FileDependencyResolver owns Python module resolution.
+//
+// A Python module path is its file path with the separators turned into dots,
+// counted from the first directory that is not a package. A directory is a
+// package when it holds an __init__.py, so walking that chain upwards is what
+// tells `pkg.sub.store` apart from `sub.store`. Relative imports are resolved
+// from the package holding the importing file, one level per leading dot.
+type FileDependencyResolver struct{}
+
+var _ dependency.Resolver = (*FileDependencyResolver)(nil)
+
+func NewFileDependencyResolver() *FileDependencyResolver {
+	return &FileDependencyResolver{}
+}
+
+func (r *FileDependencyResolver) ForFiles(files []*pb.File) dependency.ScopedResolver {
+	modules := dependency.NewIndex()
+	// Suffixes back up the package walk. A namespace package (PEP 420) has no
+	// __init__.py, so the walk stops too early and the module comes out under
+	// a shorter path than the one the imports use. A suffix is only trusted
+	// when it designates a single module.
+	suffixes := dependency.NewIndex()
+	moduleOfFile := make(map[string]string)
+
+	packages := newPackageCache()
+	for _, file := range files {
+		path := file.GetPath()
+		if file == nil || path == "" || file.GetProgrammingLanguage() != Language {
+			continue
+		}
+		module := packages.moduleOf(path)
+		if module == "" {
+			continue
+		}
+		moduleOfFile[path] = module
+		modules.Add(module, path)
+		// Indexed from the file path rather than from the module path: when
+		// the package walk stopped early, the module path is exactly what is
+		// missing its head, and the directories above it are what supply it.
+		for _, suffix := range dottedPathSuffixes(path) {
+			suffixes.Add(suffix, path)
+		}
+	}
+	return &scopedFileDependencyResolver{
+		modules:      modules,
+		suffixes:     suffixes,
+		moduleOfFile: moduleOfFile,
+	}
+}
+
+type scopedFileDependencyResolver struct {
+	modules      *dependency.Index
+	suffixes     *dependency.Index
+	moduleOfFile map[string]string
+}
+
+var _ dependency.ScopedResolver = (*scopedFileDependencyResolver)(nil)
+
+func (r *scopedFileDependencyResolver) Resolve(source *pb.File, dep *pb.StmtExternalDependency) ([]string, bool) {
+	if source == nil || dep == nil || source.GetProgrammingLanguage() != Language {
+		return nil, false
+	}
+
+	// Every dependency of a Python file is claimed, resolved or not: the
+	// standard library and the installed packages are outside the analyzed
+	// scope, and an unresolved `typing` must not fall back to matching a
+	// project class by name.
+	specifier := dep.GetNamespace()
+	if specifier == "" {
+		return nil, true
+	}
+
+	module, understood := r.rebase(source.GetPath(), specifier)
+	if !understood {
+		return nil, true
+	}
+
+	// `from pkg import name` cannot be told apart from `from pkg.mod import
+	// name` by syntax alone: the name is a submodule in the first case and an
+	// object of the module in the second. The submodule is tried first, since
+	// it is the more specific reading.
+	if name := dep.GetClassName(); name != "" {
+		if targets := r.lookup(module + "." + name); len(targets) > 0 {
+			return targets, true
+		}
+	}
+	return r.lookup(module), true
+}
+
+func (r *scopedFileDependencyResolver) lookup(module string) []string {
+	module = strings.Trim(module, ".")
+	if module == "" {
+		return nil
+	}
+	if targets := r.modules.Get(module); len(targets) > 0 {
+		return targets
+	}
+	return r.suffixes.GetUnambiguous(module)
+}
+
+// rebase turns an import specifier into an absolute module path. A specifier
+// with no leading dot is already absolute; each leading dot climbs one package
+// from the one holding the importing file.
+func (r *scopedFileDependencyResolver) rebase(sourcePath, specifier string) (string, bool) {
+	level := len(specifier) - len(strings.TrimLeft(specifier, "."))
+	if level == 0 {
+		return specifier, true
+	}
+
+	module, located := r.moduleOfFile[sourcePath]
+	if !located {
+		return "", false
+	}
+	segments := strings.Split(module, ".")
+	// The package holding the file is its module path minus the file itself,
+	// except for an __init__.py, which is the package.
+	if filepath.Base(sourcePath) != "__init__.py" {
+		segments = segments[:len(segments)-1]
+	}
+	// One dot means the current package, so only the dots beyond the first
+	// climb. A specifier that climbs past the top of the tree names something
+	// outside the analyzed sources.
+	if level-1 > len(segments) {
+		return "", false
+	}
+	segments = segments[:len(segments)-(level-1)]
+
+	base := strings.Join(segments, ".")
+	relative := strings.TrimLeft(specifier, ".")
+	if relative == "" {
+		return base, true
+	}
+	if base == "" {
+		return relative, true
+	}
+	return base + "." + relative, true
+}
+
+// dottedPathSuffixes reads a file path as a module path and lists its trailing
+// fragments, down to two segments. The last segment alone is never offered:
+// matching "store" against every file of that name would invent edges.
+func dottedPathSuffixes(path string) []string {
+	path = strings.TrimSuffix(filepath.ToSlash(filepath.Clean(path)), filepath.Ext(path))
+	segments := make([]string, 0, 8)
+	for _, segment := range strings.Split(path, "/") {
+		if segment != "" && segment != "." {
+			segments = append(segments, segment)
+		}
+	}
+	// An __init__.py is the package holding it, not a module of its own.
+	if len(segments) > 0 && segments[len(segments)-1] == "__init__" {
+		segments = segments[:len(segments)-1]
+	}
+
+	suffixes := make([]string, 0, len(segments))
+	for i := 0; i+1 < len(segments); i++ {
+		suffixes = append(suffixes, strings.Join(segments[i:], "."))
+	}
+	return suffixes
+}
+
+// packageCache maps a file to its dotted module path, remembering which
+// directories are packages so the __init__.py chain is only walked once.
+type packageCache struct {
+	isPackage map[string]bool
+}
+
+func newPackageCache() *packageCache {
+	return &packageCache{isPackage: make(map[string]bool)}
+}
+
+func (c *packageCache) moduleOf(path string) string {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		absolute = filepath.Clean(path)
+	}
+
+	segments := []string{}
+	// An __init__.py is the package holding it, not a module of its own:
+	// `import pkg` loads pkg/__init__.py.
+	if base := strings.TrimSuffix(filepath.Base(absolute), filepath.Ext(absolute)); base != "__init__" {
+		segments = append(segments, base)
+	}
+	for current := filepath.Dir(absolute); c.packageAt(current); {
+		segments = append([]string{filepath.Base(current)}, segments...)
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return strings.Join(segments, ".")
+}
+
+func (c *packageCache) packageAt(directory string) bool {
+	if known, cached := c.isPackage[directory]; cached {
+		return known
+	}
+	_, err := os.Stat(filepath.Join(directory, "__init__.py"))
+	isPackage := err == nil
+	c.isPackage[directory] = isPackage
+	return isPackage
+}

--- a/internal/engine/python/deps/resolver_test.go
+++ b/internal/engine/python/deps/resolver_test.go
@@ -1,0 +1,103 @@
+package deps
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRebaseCountsTheLeadingDots(t *testing.T) {
+	resolver := &scopedFileDependencyResolver{moduleOfFile: map[string]string{
+		"/project/pkg/sub/store.py":    "pkg.sub.store",
+		"/project/pkg/sub/__init__.py": "pkg.sub",
+	}}
+
+	tests := []struct {
+		name       string
+		sourcePath string
+		specifier  string
+		want       string
+		understood bool
+	}{
+		{
+			name:       "an absolute specifier is already a module path",
+			sourcePath: "/project/pkg/sub/store.py",
+			specifier:  "pkg.model",
+			want:       "pkg.model",
+			understood: true,
+		},
+		{
+			// One dot is the package holding the file, not its parent.
+			name:       "one dot stays in the package",
+			sourcePath: "/project/pkg/sub/store.py",
+			specifier:  ".model",
+			want:       "pkg.sub.model",
+			understood: true,
+		},
+		{
+			name:       "two dots climb to the parent package",
+			sourcePath: "/project/pkg/sub/store.py",
+			specifier:  "..model",
+			want:       "pkg.model",
+			understood: true,
+		},
+		{
+			name:       "a bare dot is the package itself",
+			sourcePath: "/project/pkg/sub/store.py",
+			specifier:  ".",
+			want:       "pkg.sub",
+			understood: true,
+		},
+		{
+			// An __init__.py is its package, so it does not shed a segment
+			// before climbing.
+			name:       "relative import from a package initializer",
+			sourcePath: "/project/pkg/sub/__init__.py",
+			specifier:  ".store",
+			want:       "pkg.sub.store",
+			understood: true,
+		},
+		{
+			name:       "climbing past the top of the tree",
+			sourcePath: "/project/pkg/sub/store.py",
+			specifier:  "....model",
+			understood: false,
+		},
+		{
+			name:       "a relative import from an unknown file",
+			sourcePath: "/project/elsewhere.py",
+			specifier:  ".model",
+			understood: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, understood := resolver.rebase(test.sourcePath, test.specifier)
+			if understood != test.understood {
+				t.Fatalf("expected understood=%v, got %v", test.understood, understood)
+			}
+			if understood && got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func TestDottedPathSuffixes(t *testing.T) {
+	want := []string{"project.pkg.sub.store", "pkg.sub.store", "sub.store"}
+	if got := dottedPathSuffixes("/project/pkg/sub/store.py"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+
+	// An __init__.py is the package holding it, not a module of its own.
+	want = []string{"project.pkg.sub", "pkg.sub"}
+	if got := dottedPathSuffixes("/project/pkg/sub/__init__.py"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+
+	// The last segment alone is never offered: "store" would match every
+	// module of that name in the project.
+	if got := dottedPathSuffixes("/store.py"); len(got) != 0 {
+		t.Fatalf("expected no suffix for a single segment, got %v", got)
+	}
+}

--- a/internal/engine/python/python_runner_test.go
+++ b/internal/engine/python/python_runner_test.go
@@ -184,11 +184,16 @@ func TestPythonParser_TreeSitter_Imports(t *testing.T) {
 	if !has("typing", "Dict") {
 		t.Fatalf("missing dep: from typing import Dict")
 	}
-	if !has("pkg", "util") {
+	// The specifier is kept as written: ".pkg" is the sibling package of the
+	// importing module, which "pkg" alone would name a different module.
+	if !has(".pkg", "util") {
 		t.Fatalf("missing dep: from .pkg import util")
 	}
-	if !has("pkg", "helpers") {
+	if !has(".pkg", "helpers") {
 		t.Fatalf("missing dep: from .pkg import helpers")
+	}
+	if has("pkg", "util") {
+		t.Fatalf("the leading dot of a relative import must not be dropped")
 	}
 }
 

--- a/internal/engine/python/tree_sitter_python_adapter.go
+++ b/internal/engine/python/tree_sitter_python_adapter.go
@@ -301,7 +301,11 @@ func importsFromImportFromStatement(a *TreeSitterAdapter, n *sitter.Node) []Tree
 			moduleNode = ch // keep the last one before `import`
 		}
 	}
-	module := strings.TrimLeft(strings.TrimSpace(a.text(moduleNode)), ".") // ".pkg" -> "pkg"
+	// The specifier is kept as written, leading dots included. They are not
+	// decoration: `from ..model import User` and `from model import User` name
+	// two different modules, and dropping the dots makes the two records
+	// identical.
+	module := strings.TrimSpace(a.text(moduleNode))
 
 	// 3) collect names: nodes AFTER cut
 	host := findDescendantOfType(n, "import_list")

--- a/internal/engine/rust/deps/resolver.go
+++ b/internal/engine/rust/deps/resolver.go
@@ -1,0 +1,266 @@
+package deps
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ast-metrics/ast-metrics/internal/engine/dependency"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// Language is the value the Rust engine writes in pb.File.ProgrammingLanguage.
+const Language = "Rust"
+
+// FileDependencyResolver owns Rust path resolution.
+//
+// Rust names modules, not files, and the mapping between the two is a
+// convention of the compiler: src/a.rs and src/a/mod.rs are both the module
+// `a`, and src/lib.rs or src/main.rs is the crate root. Each file is therefore
+// indexed under the module path it implements, and a `use` path is read
+// against the crate it starts from: `crate::` from the root, `self::` and
+// `super::` from the module doing the importing, and a leading crate name from
+// the sibling crate of the same name in a workspace.
+type FileDependencyResolver struct{}
+
+var _ dependency.Resolver = (*FileDependencyResolver)(nil)
+
+func NewFileDependencyResolver() *FileDependencyResolver {
+	return &FileDependencyResolver{}
+}
+
+// crateModule locates a file in the module tree: which crate it belongs to,
+// and the path of the module it implements inside that crate.
+type crateModule struct {
+	crate  string
+	module string
+}
+
+func (r *FileDependencyResolver) ForFiles(files []*pb.File) dependency.ScopedResolver {
+	modules := dependency.NewIndex()
+	locations := make(map[string]crateModule)
+	crateNames := make(map[string]string)
+
+	crates := newCrateCache()
+	for _, file := range files {
+		path := file.GetPath()
+		if file == nil || path == "" || file.GetProgrammingLanguage() != Language {
+			continue
+		}
+		location, found := crates.locate(path)
+		if !found {
+			continue
+		}
+		locations[path] = location
+		modules.Add(moduleKey(location.crate, location.module), path)
+		if name := crates.nameOf(location.crate); name != "" {
+			crateNames[name] = location.crate
+		}
+	}
+	return &scopedFileDependencyResolver{
+		modules:    modules,
+		locations:  locations,
+		crateNames: crateNames,
+	}
+}
+
+func moduleKey(crate, module string) string {
+	return crate + "\x00" + module
+}
+
+type scopedFileDependencyResolver struct {
+	modules    *dependency.Index
+	locations  map[string]crateModule
+	crateNames map[string]string
+}
+
+var _ dependency.ScopedResolver = (*scopedFileDependencyResolver)(nil)
+
+func (r *scopedFileDependencyResolver) Resolve(source *pb.File, dep *pb.StmtExternalDependency) ([]string, bool) {
+	if source == nil || dep == nil || source.GetProgrammingLanguage() != Language {
+		return nil, false
+	}
+
+	// Every dependency of a Rust file is claimed, resolved or not: `use
+	// std::fmt::Display` and `use serde::Serialize` name crates that are not
+	// part of the analyzed sources, and letting them fall through to name
+	// matching would bind them to whatever struct carries that name.
+	from, located := r.locations[source.GetPath()]
+	if !located {
+		return nil, true
+	}
+
+	// The dependency was split into a module part and a leaf name; the path as
+	// written is the two joined back together, since the split point is a
+	// guess that the module tree is about to correct.
+	path := dep.GetNamespace()
+	if leaf := dep.GetClassName(); leaf != "" {
+		path = strings.TrimSuffix(path, "::") + "::" + leaf
+		path = strings.TrimPrefix(path, "::")
+	}
+
+	crate, segments, understood := r.rebase(from, path)
+	if !understood {
+		return nil, true
+	}
+
+	// A use path ends on an item, not on a module: `crate::model::User` names
+	// the struct User inside the module `model`. Which trailing segments are
+	// items is only known to the compiler, so the longest prefix that is a
+	// module wins.
+	for end := len(segments); end >= 0; end-- {
+		module := strings.Join(segments[:end], "::")
+		if targets := r.modules.Get(moduleKey(crate, module)); len(targets) > 0 {
+			return targets, true
+		}
+	}
+	return nil, true
+}
+
+// rebase turns a use path into a crate and the module segments to walk from
+// its root, resolving the three ways Rust can anchor a path.
+func (r *scopedFileDependencyResolver) rebase(from crateModule, path string) (string, []string, bool) {
+	segments := splitPath(path)
+	if len(segments) == 0 {
+		return "", nil, false
+	}
+
+	current := splitPath(from.module)
+	switch segments[0] {
+	case "crate":
+		return from.crate, segments[1:], true
+	case "self":
+		return from.crate, append(append([]string{}, current...), segments[1:]...), true
+	case "super":
+		// Each `super` climbs one module, and they can be chained.
+		rest := segments
+		for len(rest) > 0 && rest[0] == "super" {
+			if len(current) == 0 {
+				return "", nil, false
+			}
+			current = current[:len(current)-1]
+			rest = rest[1:]
+		}
+		return from.crate, append(append([]string{}, current...), rest...), true
+	}
+
+	// A sibling crate of the workspace, named as its Cargo.toml declares it.
+	if crate, found := r.crateNames[segments[0]]; found && crate != from.crate {
+		return crate, segments[1:], true
+	}
+	// Otherwise the path is read from the crate root, which is how the 2015
+	// edition spells `use module::Item`. An external crate simply finds no
+	// module of that name and resolves to nothing.
+	return from.crate, segments, true
+}
+
+func splitPath(path string) []string {
+	segments := make([]string, 0, 4)
+	for _, segment := range strings.Split(path, "::") {
+		if segment = strings.TrimSpace(segment); segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+	return segments
+}
+
+// crateCache maps a file to its place in the module tree, remembering the
+// Cargo.toml files found while walking up. A workspace holds several crates,
+// so the search stops at the nearest manifest rather than at a single root.
+type crateCache struct {
+	// nameByRoot maps a crate root directory to the package name declared in
+	// its Cargo.toml, with an empty value marking a directory known to hold no
+	// readable manifest.
+	nameByRoot map[string]string
+}
+
+func newCrateCache() *crateCache {
+	return &crateCache{nameByRoot: make(map[string]string)}
+}
+
+func (c *crateCache) locate(path string) (crateModule, bool) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		absolute = filepath.Clean(path)
+	}
+	// The source directory of the crate, which the module paths are relative
+	// to. Anything outside a src/ directory is not part of a crate laid out
+	// the way cargo expects.
+	sourceRoot := sourceRootOf(absolute)
+	if sourceRoot == "" {
+		return crateModule{}, false
+	}
+	crate := filepath.Dir(sourceRoot)
+	c.nameOf(crate)
+	return crateModule{crate: crate, module: moduleOf(sourceRoot, absolute)}, true
+}
+
+func (c *crateCache) nameOf(crate string) string {
+	if name, known := c.nameByRoot[crate]; known {
+		return name
+	}
+	name := ""
+	if content, err := os.ReadFile(filepath.Join(crate, "Cargo.toml")); err == nil {
+		name = packageNameIn(string(content))
+	}
+	c.nameByRoot[crate] = name
+	return name
+}
+
+// sourceRootOf returns the innermost "src" directory above a file, which is
+// where a crate's module tree starts.
+func sourceRootOf(path string) string {
+	for current := filepath.Dir(path); ; {
+		if filepath.Base(current) == "src" {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return ""
+		}
+		current = parent
+	}
+}
+
+// moduleOf reads the module path a file implements from its place under the
+// source root: lib.rs and main.rs are the crate root, a/mod.rs and a.rs are
+// both the module `a`.
+func moduleOf(sourceRoot, path string) string {
+	relative, err := filepath.Rel(sourceRoot, path)
+	if err != nil {
+		return ""
+	}
+	segments := strings.Split(filepath.ToSlash(relative), "/")
+	last := len(segments) - 1
+	switch strings.TrimSuffix(segments[last], ".rs") {
+	case "lib", "main", "mod":
+		segments = segments[:last]
+	default:
+		segments[last] = strings.TrimSuffix(segments[last], ".rs")
+	}
+	return strings.Join(segments, "::")
+}
+
+// packageNameIn reads the package name out of a Cargo.toml. Only the name of
+// the [package] section is needed, so the file is scanned rather than parsed.
+// Cargo lets a crate be named with dashes and referred to with underscores.
+func packageNameIn(content string) string {
+	inPackage := false
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "[") {
+			inPackage = line == "[package]"
+			continue
+		}
+		if !inPackage {
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		// The key is compared whole, so that "names" does not pass for "name".
+		if !found || strings.TrimSpace(key) != "name" {
+			continue
+		}
+		return strings.ReplaceAll(strings.Trim(strings.TrimSpace(value), `"'`), "-", "_")
+	}
+	return ""
+}

--- a/internal/engine/rust/deps/resolver_test.go
+++ b/internal/engine/rust/deps/resolver_test.go
@@ -1,0 +1,119 @@
+package deps
+
+import "testing"
+
+func TestModuleOf(t *testing.T) {
+	const sourceRoot = "/project/src"
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "library root", path: "/project/src/lib.rs", want: ""},
+		{name: "binary root", path: "/project/src/main.rs", want: ""},
+		{name: "module written as a file", path: "/project/src/model.rs", want: "model"},
+		{name: "module written as a directory", path: "/project/src/store/mod.rs", want: "store"},
+		{name: "nested module", path: "/project/src/store/inner.rs", want: "store::inner"},
+		{name: "nested directory module", path: "/project/src/a/b/mod.rs", want: "a::b"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := moduleOf(sourceRoot, test.path); got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func TestPackageNameIn(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "plain package",
+			content: "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+			want:    "demo",
+		},
+		{
+			// Cargo lets a crate be named with dashes and referred to in code
+			// with underscores, which is the form a use path carries.
+			name:    "dashes become underscores",
+			content: "[package]\nname = \"demo-core\"\n",
+			want:    "demo_core",
+		},
+		{
+			name:    "a name outside the package section is not the crate name",
+			content: "[dependencies]\nname = \"serde\"\n\n[package]\nname = \"demo\"\n",
+			want:    "demo",
+		},
+		{
+			name:    "a virtual workspace manifest declares no package",
+			content: "[workspace]\nmembers = [\"core\", \"app\"]\n",
+			want:    "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := packageNameIn(test.content); got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func TestRebaseAnchorsAPath(t *testing.T) {
+	resolver := &scopedFileDependencyResolver{
+		crateNames: map[string]string{"demo_core": "/other"},
+	}
+	from := crateModule{crate: "/project", module: "a::b"}
+
+	tests := []struct {
+		name       string
+		path       string
+		wantCrate  string
+		wantJoined string
+		understood bool
+	}{
+		{name: "crate root", path: "crate::model::User", wantCrate: "/project", wantJoined: "model::User", understood: true},
+		{name: "self", path: "self::inner::Thing", wantCrate: "/project", wantJoined: "a::b::inner::Thing", understood: true},
+		{name: "super", path: "super::Store", wantCrate: "/project", wantJoined: "a::Store", understood: true},
+		{name: "chained super", path: "super::super::Top", wantCrate: "/project", wantJoined: "Top", understood: true},
+		{name: "another crate of the workspace", path: "demo_core::Config", wantCrate: "/other", wantJoined: "Config", understood: true},
+		{name: "read from the crate root otherwise", path: "model::User", wantCrate: "/project", wantJoined: "model::User", understood: true},
+		{name: "climbing above the crate root", path: "super::super::super::Nope", understood: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			crate, segments, understood := resolver.rebase(from, test.path)
+			if understood != test.understood {
+				t.Fatalf("expected understood=%v, got %v", test.understood, understood)
+			}
+			if !understood {
+				return
+			}
+			if crate != test.wantCrate {
+				t.Fatalf("expected crate %q, got %q", test.wantCrate, crate)
+			}
+			if joined := joinPath(segments); joined != test.wantJoined {
+				t.Fatalf("expected path %q, got %q", test.wantJoined, joined)
+			}
+		})
+	}
+}
+
+func joinPath(segments []string) string {
+	joined := ""
+	for i, segment := range segments {
+		if i > 0 {
+			joined += "::"
+		}
+		joined += segment
+	}
+	return joined
+}

--- a/internal/engine/rust/tree_sitter_rust_adapter.go
+++ b/internal/engine/rust/tree_sitter_rust_adapter.go
@@ -261,10 +261,32 @@ func (a *TreeSitterAdapter) Imports(n *sitter.Node) []Treesitter.ImportItem {
 	if n == nil {
 		return nil
 	}
-	if n.Type() != "use_declaration" {
+	switch n.Type() {
+	case "use_declaration":
+		return a.parseUse(n)
+	case "mod_item":
+		return a.parseMod(n)
+	}
+	return nil
+}
+
+// parseMod records a `mod x;` declaration as a dependency on the module it
+// pulls in. It is the other half of the Rust module graph: `use` says which
+// items a file reads, `mod` says which files make up the crate at all. A
+// module written inline (`mod x { ... }`) declares no dependency, since it
+// brings in no other file.
+func (a *TreeSitterAdapter) parseMod(n *sitter.Node) []Treesitter.ImportItem {
+	if n.ChildByFieldName("body") != nil {
 		return nil
 	}
-	return a.parseUse(n)
+	name := a.text(n.ChildByFieldName("name"))
+	if name == "" {
+		return nil
+	}
+	// `self::` marks the path as relative to the declaring module, which is
+	// exactly what `mod` means and what tells the resolver not to read it as
+	// a crate name.
+	return []Treesitter.ImportItem{{Module: "self::" + name}}
 }
 
 func (a *TreeSitterAdapter) parseUse(n *sitter.Node) []Treesitter.ImportItem {

--- a/internal/engine/typescript/deps/resolver.go
+++ b/internal/engine/typescript/deps/resolver.go
@@ -1,0 +1,259 @@
+package deps
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ast-metrics/ast-metrics/internal/engine/dependency"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+// FileDependencyResolver owns TypeScript module resolution. The project-level
+// analyzer only consumes its language-neutral Resolver contract.
+type FileDependencyResolver struct{}
+
+var _ dependency.Resolver = (*FileDependencyResolver)(nil)
+
+func NewFileDependencyResolver() *FileDependencyResolver {
+	return &FileDependencyResolver{}
+}
+
+func (r *FileDependencyResolver) ForFiles(files []*pb.File) dependency.ScopedResolver {
+	index := newModuleIndex()
+	moduleDependencies := make(map[*pb.File]map[dependencyIdentity]struct{})
+	for _, file := range files {
+		if file == nil || file.GetProgrammingLanguage() != "TypeScript" {
+			continue
+		}
+		index.add(file.GetPath())
+		moduleDependencies[file] = dependenciesAttachedToModules(file)
+	}
+	index.sort()
+	return &scopedFileDependencyResolver{
+		modules:            index,
+		moduleDependencies: moduleDependencies,
+	}
+}
+
+type scopedFileDependencyResolver struct {
+	modules            *moduleIndex
+	moduleDependencies map[*pb.File]map[dependencyIdentity]struct{}
+}
+
+var _ dependency.ScopedResolver = (*scopedFileDependencyResolver)(nil)
+
+func (r *scopedFileDependencyResolver) Resolve(source *pb.File, dep *pb.StmtExternalDependency) ([]string, bool) {
+	if source == nil || dep == nil || source.GetProgrammingLanguage() != "TypeScript" {
+		return nil, false
+	}
+
+	specifier := dep.GetNamespace()
+	_, isModuleDependency := r.moduleDependencies[source][identityOf(dep)]
+	if !isModuleDependency && !isRelativeSpecifier(specifier) {
+		return nil, false
+	}
+
+	// A bare package import and a missing relative import are both handled:
+	// neither may fall through to symbol matching and bind to an unrelated
+	// class with the same name.
+	if target := r.modules.resolveRelative(source.GetPath(), specifier); target != "" {
+		return []string{target}, true
+	}
+	return nil, true
+}
+
+type dependencyIdentity struct {
+	namespace    string
+	className    string
+	functionName string
+	from         string
+}
+
+func identityOf(dep *pb.StmtExternalDependency) dependencyIdentity {
+	return dependencyIdentity{
+		namespace:    dep.GetNamespace(),
+		className:    dep.GetClassName(),
+		functionName: dep.GetFunctionName(),
+		from:         dep.GetFrom(),
+	}
+}
+
+// The tree-sitter visitor attaches TypeScript imports and re-exports to their
+// namespace. This identifies module dependencies without changing the shared
+// protobuf model or confusing them with class references synthesized later.
+func dependenciesAttachedToModules(file *pb.File) map[dependencyIdentity]struct{} {
+	dependencies := make(map[dependencyIdentity]struct{})
+	if file == nil || file.Stmts == nil {
+		return dependencies
+	}
+	for _, namespace := range file.Stmts.GetStmtNamespace() {
+		if namespace == nil || namespace.Stmts == nil {
+			continue
+		}
+		for _, dep := range namespace.Stmts.GetStmtExternalDependencies() {
+			if dep != nil {
+				dependencies[identityOf(dep)] = struct{}{}
+			}
+		}
+	}
+	return dependencies
+}
+
+// Longer suffixes come first so declarations lose ".d.ts", not just ".ts".
+var resolveExtensions = []string{
+	".d.mts", ".d.cts", ".d.ts",
+	".mts", ".cts", ".tsx", ".ts",
+	".jsx", ".js", ".mjs", ".cjs", ".vue",
+}
+
+var extensionPriorities = map[string]int{
+	".ts": 0, ".tsx": 1, ".mts": 2, ".cts": 3,
+	".d.ts": 4, ".d.mts": 5, ".d.cts": 6,
+	".js": 7, ".jsx": 8, ".mjs": 9, ".cjs": 10, ".vue": 11,
+}
+
+func resolveExtension(path string) string {
+	for _, extension := range resolveExtensions {
+		if strings.HasSuffix(path, extension) {
+			return extension
+		}
+	}
+	return ""
+}
+
+func stripResolveExtension(path string) string {
+	return strings.TrimSuffix(path, resolveExtension(path))
+}
+
+type moduleCandidate struct {
+	path      string
+	extension string
+	priority  int
+	indexFile bool
+}
+
+// moduleIndex keeps every candidate instead of silently overwriting
+// collisions such as foo.ts/foo.tsx. Sorting makes resolution independent of
+// the parser's concurrent file order.
+type moduleIndex struct {
+	exact      map[string][]string
+	candidates map[string][]moduleCandidate
+}
+
+func newModuleIndex() *moduleIndex {
+	return &moduleIndex{
+		exact:      make(map[string][]string),
+		candidates: make(map[string][]moduleCandidate),
+	}
+}
+
+func (index *moduleIndex) add(path string) {
+	cleanPath := filepath.Clean(path)
+	extension := resolveExtension(cleanPath)
+	if extension == "" {
+		return
+	}
+	if !containsPath(index.exact[cleanPath], path) {
+		index.exact[cleanPath] = append(index.exact[cleanPath], path)
+	}
+
+	modulePath := stripResolveExtension(cleanPath)
+	index.addCandidate(modulePath, moduleCandidate{
+		path:      path,
+		extension: extension,
+		priority:  extensionPriority(extension),
+	})
+	if filepath.Base(modulePath) == "index" {
+		index.addCandidate(filepath.Dir(modulePath), moduleCandidate{
+			path:      path,
+			extension: extension,
+			priority:  extensionPriority(extension),
+			indexFile: true,
+		})
+	}
+}
+
+func (index *moduleIndex) addCandidate(modulePath string, candidate moduleCandidate) {
+	for _, existing := range index.candidates[modulePath] {
+		if existing.path == candidate.path {
+			return
+		}
+	}
+	index.candidates[modulePath] = append(index.candidates[modulePath], candidate)
+}
+
+func containsPath(paths []string, path string) bool {
+	for _, existing := range paths {
+		if existing == path {
+			return true
+		}
+	}
+	return false
+}
+
+func (index *moduleIndex) sort() {
+	for cleanPath := range index.exact {
+		sort.Strings(index.exact[cleanPath])
+	}
+	for modulePath, candidates := range index.candidates {
+		sort.Slice(candidates, func(i, j int) bool {
+			if candidates[i].indexFile != candidates[j].indexFile {
+				return !candidates[i].indexFile
+			}
+			if candidates[i].priority != candidates[j].priority {
+				return candidates[i].priority < candidates[j].priority
+			}
+			return candidates[i].path < candidates[j].path
+		})
+		index.candidates[modulePath] = candidates
+	}
+}
+
+func extensionPriority(extension string) int {
+	if priority, found := extensionPriorities[extension]; found {
+		return priority
+	}
+	return len(resolveExtensions)
+}
+
+func isRelativeSpecifier(specifier string) bool {
+	return specifier == "." || specifier == ".." ||
+		strings.HasPrefix(specifier, "./") || strings.HasPrefix(specifier, "../")
+}
+
+func (index *moduleIndex) resolveRelative(fromPath, specifier string) string {
+	if !isRelativeSpecifier(specifier) {
+		return ""
+	}
+	joined := filepath.Clean(filepath.Join(filepath.Dir(fromPath), specifier))
+	requestedExtension := resolveExtension(joined)
+	if requestedExtension != "" {
+		if exact := index.exact[joined]; len(exact) > 0 {
+			return exact[0]
+		}
+	}
+	for _, candidate := range index.candidates[stripResolveExtension(joined)] {
+		if requestedExtension == "" || isExtensionSubstitution(requestedExtension, candidate.extension) {
+			return candidate.path
+		}
+	}
+	return ""
+}
+
+// TypeScript substitutes source extensions when emitted JavaScript paths are
+// imported. Other explicit extensions (notably .vue) must match exactly.
+func isExtensionSubstitution(requested, candidate string) bool {
+	switch requested {
+	case ".js":
+		return candidate == ".ts" || candidate == ".tsx" || candidate == ".d.ts"
+	case ".jsx":
+		return candidate == ".tsx" || candidate == ".d.ts"
+	case ".mjs":
+		return candidate == ".mts" || candidate == ".d.mts"
+	case ".cjs":
+		return candidate == ".cts" || candidate == ".d.cts"
+	default:
+		return false
+	}
+}

--- a/internal/engine/typescript/deps/resolver_test.go
+++ b/internal/engine/typescript/deps/resolver_test.go
@@ -1,0 +1,187 @@
+package deps
+
+import (
+	"testing"
+
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+func fileWithModuleDependency(path, specifier, className string) (*pb.File, *pb.StmtExternalDependency) {
+	dep := &pb.StmtExternalDependency{
+		Namespace: specifier,
+		ClassName: className,
+		From:      "source",
+	}
+	return &pb.File{
+		Path:                path,
+		ProgrammingLanguage: "TypeScript",
+		Stmts: &pb.Stmts{StmtNamespace: []*pb.StmtNamespace{{
+			Stmts: &pb.Stmts{StmtExternalDependencies: []*pb.StmtExternalDependency{dep}},
+		}}},
+	}, dep
+}
+
+func typeScriptFile(path string) *pb.File {
+	return &pb.File{Path: path, ProgrammingLanguage: "TypeScript", Stmts: &pb.Stmts{}}
+}
+
+func resolveTypeScriptDependency(files []*pb.File, source *pb.File, dep *pb.StmtExternalDependency) (string, bool) {
+	// A TypeScript specifier names one module, so the tests below read the
+	// single target the resolver is expected to produce.
+	targets, handled := NewFileDependencyResolver().ForFiles(files).Resolve(source, dep)
+	if len(targets) == 0 {
+		return "", handled
+	}
+	return targets[0], handled
+}
+
+func TestFileDependencyResolverResolvesRelativeModules(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourcePath string
+		specifier  string
+		targetPath string
+	}{
+		{
+			name:       "extensionless sibling",
+			sourcePath: "/tmp/project/Foo.ts",
+			specifier:  "./Bar",
+			targetPath: "/tmp/project/Bar.ts",
+		},
+		{
+			name:       "directory index",
+			sourcePath: "/tmp/project/Foo.ts",
+			specifier:  "./bar",
+			targetPath: "/tmp/project/bar/index.ts",
+		},
+		{
+			name:       "parent directory",
+			sourcePath: "/tmp/project/feature/Foo.ts",
+			specifier:  "../Bar",
+			targetPath: "/tmp/project/Bar.ts",
+		},
+		{
+			name:       "explicit vue extension",
+			sourcePath: "/tmp/project/Modal.ts",
+			specifier:  "./steps/CelebrationStep.vue",
+			targetPath: "/tmp/project/steps/CelebrationStep.vue",
+		},
+		{
+			name:       "modern mts extension",
+			sourcePath: "/tmp/project/Foo.ts",
+			specifier:  "./Bar",
+			targetPath: "/tmp/project/Bar.mts",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source, dep := fileWithModuleDependency(test.sourcePath, test.specifier, "Bar")
+			target := typeScriptFile(test.targetPath)
+
+			got, handled := resolveTypeScriptDependency([]*pb.File{source, target}, source, dep)
+			if !handled || got != target.Path {
+				t.Fatalf("expected %q to resolve to %q, got %q (handled=%t)", test.specifier, target.Path, got, handled)
+			}
+		})
+	}
+}
+
+func TestFileDependencyResolverUsesDeterministicPrecedence(t *testing.T) {
+	source, dep := fileWithModuleDependency("/tmp/project/Foo.ts", "./Bar", "Bar")
+	targetTS := typeScriptFile("/tmp/project/Bar.ts")
+	targetTSX := typeScriptFile("/tmp/project/Bar.tsx")
+
+	for _, files := range [][]*pb.File{
+		{source, targetTS, targetTSX},
+		{source, targetTSX, targetTS},
+	} {
+		got, handled := resolveTypeScriptDependency(files, source, dep)
+		if !handled || got != targetTS.Path {
+			t.Fatalf("expected stable .ts precedence, got %q (handled=%t)", got, handled)
+		}
+	}
+}
+
+func TestFileDependencyResolverUsesDeterministicExactPath(t *testing.T) {
+	source, dep := fileWithModuleDependency("/tmp/project/Foo.ts", "./Bar.ts", "Bar")
+	canonical := typeScriptFile("/tmp/project/Bar.ts")
+	alias := typeScriptFile("/tmp/project/sub/../Bar.ts")
+
+	for _, files := range [][]*pb.File{
+		{source, canonical, alias},
+		{source, alias, canonical},
+	} {
+		got, handled := resolveTypeScriptDependency(files, source, dep)
+		if !handled || got != canonical.Path {
+			t.Fatalf("expected stable exact path %q, got %q (handled=%t)", canonical.Path, got, handled)
+		}
+	}
+}
+
+func TestFileDependencyResolverPrefersExplicitExtension(t *testing.T) {
+	source, dep := fileWithModuleDependency("/tmp/project/Foo.ts", "./Bar.tsx", "Bar")
+	targetTS := typeScriptFile("/tmp/project/Bar.ts")
+	targetTSX := typeScriptFile("/tmp/project/Bar.tsx")
+
+	got, handled := resolveTypeScriptDependency([]*pb.File{source, targetTS, targetTSX}, source, dep)
+	if !handled || got != targetTSX.Path {
+		t.Fatalf("expected explicit .tsx target, got %q (handled=%t)", got, handled)
+	}
+}
+
+func TestFileDependencyResolverOnlySubstitutesJavaScriptExtensions(t *testing.T) {
+	tests := []struct {
+		name      string
+		specifier string
+		target    string
+		want      string
+	}{
+		{name: "emitted js path", specifier: "./Bar.js", target: "/tmp/project/Bar.ts", want: "/tmp/project/Bar.ts"},
+		{name: "emitted mjs path", specifier: "./Bar.mjs", target: "/tmp/project/Bar.mts", want: "/tmp/project/Bar.mts"},
+		{name: "missing vue file", specifier: "./Bar.vue", target: "/tmp/project/Bar.ts"},
+		{name: "missing ts file", specifier: "./Bar.ts", target: "/tmp/project/Bar.tsx"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source, dep := fileWithModuleDependency("/tmp/project/Foo.ts", test.specifier, "Bar")
+			target := typeScriptFile(test.target)
+			got, handled := resolveTypeScriptDependency([]*pb.File{source, target}, source, dep)
+			if !handled || got != test.want {
+				t.Fatalf("expected target %q, got %q (handled=%t)", test.want, got, handled)
+			}
+		})
+	}
+}
+
+func TestFileDependencyResolverClaimsUnresolvedModules(t *testing.T) {
+	tests := []struct {
+		name      string
+		specifier string
+	}{
+		{name: "external package", specifier: "react"},
+		{name: "missing relative module", specifier: "./missing"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source, dep := fileWithModuleDependency("/tmp/project/Foo.ts", test.specifier, "React")
+			got, handled := resolveTypeScriptDependency([]*pb.File{source}, source, dep)
+			if !handled || got != "" {
+				t.Fatalf("expected an unresolved handled module, got %q (handled=%t)", got, handled)
+			}
+		})
+	}
+}
+
+func TestFileDependencyResolverIgnoresSymbolDependencies(t *testing.T) {
+	source := typeScriptFile("/tmp/project/Foo.ts")
+	dep := &pb.StmtExternalDependency{ClassName: "Bar", Namespace: "pkg"}
+	target := typeScriptFile("/tmp/project/Bar.ts")
+
+	got, handled := resolveTypeScriptDependency([]*pb.File{source, target}, source, dep)
+	if handled || got != "" {
+		t.Fatalf("expected symbol dependency to fall through, got %q (handled=%t)", got, handled)
+	}
+}

--- a/internal/engine/typescript/tree_sitter_typescript_adapter.go
+++ b/internal/engine/typescript/tree_sitter_typescript_adapter.go
@@ -235,28 +235,39 @@ func (a *TreeSitterAdapter) Imports(n *sitter.Node) []Treesitter.ImportItem {
 	if n == nil {
 		return nil
 	}
-	if n.Type() != "import_statement" {
+	switch n.Type() {
+	case "import_statement":
+		return a.importsFromImportStatement(n)
+	case "export_statement":
+		// A re-export (`export ... from 'module'`) is a dependency on that
+		// module just like an import; a local export (no `from` clause) is not.
+		return a.importsFromExportStatement(n)
+	default:
 		return nil
 	}
-	items := []Treesitter.ImportItem{}
+}
 
-	// Find the source module (the string literal at the end)
-	var module string
+// moduleOf reads the source module string of an import/export statement (the
+// string literal in its "source" field, falling back to the first string
+// child for grammars that don't expose the field).
+func (a *TreeSitterAdapter) moduleOf(n *sitter.Node) string {
 	if src := n.ChildByFieldName("source"); src != nil {
-		module = stripQuotes(text(a.src, src))
-	} else {
-		// fallback: find a string child
-		for i := 0; i < int(n.ChildCount()); i++ {
-			ch := n.Child(i)
-			if ch.Type() == "string" {
-				module = stripQuotes(text(a.src, ch))
-				break
-			}
+		return stripQuotes(text(a.src, src))
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if ch := n.Child(i); ch.Type() == "string" {
+			return stripQuotes(text(a.src, ch))
 		}
 	}
+	return ""
+}
+
+func (a *TreeSitterAdapter) importsFromImportStatement(n *sitter.Node) []Treesitter.ImportItem {
+	module := a.moduleOf(n)
 	if module == "" {
 		return nil
 	}
+	items := []Treesitter.ImportItem{}
 
 	// Walk import clause children
 	var walkClause func(*sitter.Node)
@@ -297,6 +308,50 @@ func (a *TreeSitterAdapter) Imports(n *sitter.Node) []Treesitter.ImportItem {
 	}
 
 	// If no symbols found, record as plain module import
+	if len(items) == 0 {
+		items = append(items, Treesitter.ImportItem{Module: module})
+	}
+	return items
+}
+
+// importsFromExportStatement handles re-exports: `export * from 'module'`,
+// `export * as ns from 'module'`, and `export { a, b as c } from 'module'`
+// (optionally prefixed with `type`). These reference another module just like
+// an import does, so barrel files (`export * from './components'`) are
+// tracked as dependencies rather than silently dropped.
+func (a *TreeSitterAdapter) importsFromExportStatement(n *sitter.Node) []Treesitter.ImportItem {
+	if n.ChildByFieldName("source") == nil {
+		// Local export (`export { d }`, `export const x = ...`): no module involved.
+		return nil
+	}
+	module := a.moduleOf(n)
+	if module == "" {
+		return nil
+	}
+	items := []Treesitter.ImportItem{}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		ch := n.Child(i)
+		switch ch.Type() {
+		case "export_clause":
+			for j := 0; j < int(ch.ChildCount()); j++ {
+				spec := ch.Child(j)
+				if spec.Type() == "export_specifier" {
+					if nm := spec.ChildByFieldName("name"); nm != nil {
+						items = append(items, Treesitter.ImportItem{Module: module, Name: text(a.src, nm)})
+					} else if id := firstChildOfType(spec, "identifier"); id != nil {
+						items = append(items, Treesitter.ImportItem{Module: module, Name: text(a.src, id)})
+					}
+				}
+			}
+		case "namespace_export":
+			// export * as ns from 'module'
+			if id := firstChildOfType(ch, "identifier"); id != nil {
+				items = append(items, Treesitter.ImportItem{Module: module, Name: text(a.src, id)})
+			}
+		}
+	}
+
+	// export * from 'module', or nothing more specific found: record as a plain module dependency.
 	if len(items) == 0 {
 		items = append(items, Treesitter.ImportItem{Module: module})
 	}

--- a/internal/engine/typescript/typescript_lcom_test.go
+++ b/internal/engine/typescript/typescript_lcom_test.go
@@ -1,4 +1,4 @@
-package typescript
+package typescript_test
 
 import (
 	"slices"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	"github.com/ast-metrics/ast-metrics/internal/engine"
+	"github.com/ast-metrics/ast-metrics/internal/engine/typescript"
 )
 
 const sampleTsClass = `class Basket {
@@ -37,7 +38,7 @@ const sampleTsClass = `class Basket {
 `
 
 func Test_Ts_Class_Has_Lack_Of_Cohesion(t *testing.T) {
-	file, err := engine.CreateTestFileWithCode(&TypeScriptRunner{}, sampleTsClass)
+	file, err := engine.CreateTestFileWithCode(&typescript.TypeScriptRunner{}, sampleTsClass)
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
@@ -60,7 +61,7 @@ func Test_Ts_Class_Has_Lack_Of_Cohesion(t *testing.T) {
 }
 
 func Test_Ts_Attribute_Access_Is_An_Operand_And_Not_A_Call(t *testing.T) {
-	adapter := NewTreeSitterAdapter([]byte(sampleTsClass))
+	adapter := typescript.NewTreeSitterAdapter([]byte(sampleTsClass))
 	src := []byte(sampleTsClass)
 
 	// `rename(label: string): void {` ... on lines 17 to 20
@@ -104,7 +105,7 @@ func Test_Ts_Type_Annotations_Are_Not_Operands(t *testing.T) {
     }
 }
 `)
-	adapter := NewTreeSitterAdapter(src)
+	adapter := typescript.NewTreeSitterAdapter(src)
 	operators, operands := adapter.ExtractOperatorsOperands(src, 1, 8)
 
 	// the types, wherever they stand (parameter, result, declaration, generic
@@ -138,7 +139,7 @@ func Test_Ts_Operands_Keep_Member_Access_Chains(t *testing.T) {
     }
 }
 `)
-	adapter := NewTreeSitterAdapter(src)
+	adapter := typescript.NewTreeSitterAdapter(src)
 	_, operands := adapter.ExtractOperatorsOperands(src, 2, 7)
 
 	for _, expected := range []string{"this.total", "console.log", "message", "size", "this.items"} {

--- a/internal/engine/typescript/typescript_runner_test.go
+++ b/internal/engine/typescript/typescript_runner_test.go
@@ -2,6 +2,7 @@ package typescript
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	enginePkg "github.com/ast-metrics/ast-metrics/internal/engine"
@@ -144,8 +145,9 @@ func TestTypeScriptParser_TreeSitter_Decisions(t *testing.T) {
 
 const sampleImports = `
 import fs from 'fs';
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile as write } from 'fs/promises';
 import * as path from 'path';
+import './setup';
 `
 
 func TestTypeScriptParser_TreeSitter_Imports(t *testing.T) {
@@ -162,34 +164,65 @@ func TestTypeScriptParser_TreeSitter_Imports(t *testing.T) {
 		t.Fatalf("nil ns stmts")
 	}
 
-	got := len(ns.Stmts.StmtExternalDependencies)
-	if got < 4 {
-		t.Fatalf("expected at least 4 external deps, got %d", got)
+	assertTypeScriptDependencies(t, ns.Stmts.StmtExternalDependencies, map[importKey]struct{}{
+		{module: "fs", name: "fs"}:                 {},
+		{module: "fs/promises", name: "readFile"}:  {},
+		{module: "fs/promises", name: "writeFile"}: {},
+		{module: "path", name: "path"}:             {},
+		{module: "./setup"}:                        {},
+	})
+}
+
+const sampleReExports = `
+export * from './components';
+export * as ns from './bar';
+export { a, b as c } from './foo';
+export type { X } from './types';
+export { local };
+`
+
+func TestTypeScriptParser_TreeSitter_ReExports(t *testing.T) {
+	r := &TypeScriptRunner{}
+	file, err := enginePkg.CreateTestFileWithCode(r, sampleReExports)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if file == nil || file.Stmts == nil || len(file.Stmts.StmtNamespace) != 1 {
+		t.Fatalf("invalid file/namespace")
+	}
+	ns := file.Stmts.StmtNamespace[0]
+	if ns == nil || ns.Stmts == nil {
+		t.Fatalf("nil ns stmts")
 	}
 
-	has := func(module, name string) bool {
-		for _, d := range ns.Stmts.StmtExternalDependencies {
-			if d.Namespace == module && d.ClassName == name {
-				return true
-			}
-			if name == "" && d.Namespace == module {
-				return true
-			}
+	assertTypeScriptDependencies(t, ns.Stmts.StmtExternalDependencies, map[importKey]struct{}{
+		{module: "./components"}:       {},
+		{module: "./bar", name: "ns"}:  {},
+		{module: "./foo", name: "a"}:   {},
+		{module: "./foo", name: "b"}:   {},
+		{module: "./types", name: "X"}: {},
+	})
+}
+
+type importKey struct {
+	module string
+	name   string
+}
+
+func assertTypeScriptDependencies(t *testing.T, dependencies []*pb.StmtExternalDependency, want map[importKey]struct{}) {
+	t.Helper()
+	if len(dependencies) != len(want) {
+		t.Fatalf("expected %d dependencies, got %d: %+v", len(want), len(dependencies), dependencies)
+	}
+	got := make(map[importKey]struct{}, len(dependencies))
+	for _, dependency := range dependencies {
+		if dependency == nil {
+			t.Fatal("unexpected nil dependency")
 		}
-		return false
+		got[importKey{module: dependency.GetNamespace(), name: dependency.GetClassName()}] = struct{}{}
 	}
-
-	if !has("fs", "fs") {
-		t.Fatalf("missing dep: import fs from 'fs'")
-	}
-	if !has("fs/promises", "readFile") {
-		t.Fatalf("missing dep: import { readFile } from 'fs/promises'")
-	}
-	if !has("fs/promises", "writeFile") {
-		t.Fatalf("missing dep: import { writeFile } from 'fs/promises'")
-	}
-	if !has("path", "path") {
-		t.Fatalf("missing dep: import * as path from 'path'")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected dependencies:\nwant: %v\ngot:  %v", want, got)
 	}
 }
 

--- a/internal/engine/util.go
+++ b/internal/engine/util.go
@@ -552,9 +552,9 @@ func GetDependenciesInFile(file *pb.File) []*pb.StmtExternalDependency {
 		if _, ok := uniq[k]; ok {
 			return
 		}
-		// Make a shallow copy to avoid accidental mutation
-		cpy := *dep
-		uniq[k] = &cpy
+		// Clone protobuf state as well as fields; a struct assignment would copy
+		// the message's internal mutex.
+		uniq[k] = proto.Clone(dep).(*pb.StmtExternalDependency)
 	}
 
 	// 1) file-level externals

--- a/internal/report/html_report_generator.go
+++ b/internal/report/html_report_generator.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -16,13 +15,13 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/flosch/pongo2/v5"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer/classifier"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer/requirement"
 	"github.com/ast-metrics/ast-metrics/internal/engine"
 	"github.com/ast-metrics/ast-metrics/internal/ui"
 	pb "github.com/ast-metrics/ast-metrics/pb"
+	"github.com/flosch/pongo2/v5"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -184,7 +183,7 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 			cd.testQualityJSON = analyzer.BuildTestQualityJSON(currentView.TestQuality)
 		}
 
-		cd.fileDepsJSON = buildFileDepsJSON(files, scope.Keep, dict)
+		cd.fileDepsJSON = buildFileDepsJSON(currentView.FileDependencies, dict)
 
 		// Count files for this scope
 		fileCount := 0
@@ -197,7 +196,7 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		cd.depFileCount = fileCount
 
 		// Build folder-level deps for dependency graph folder view
-		cd.folderDepsJSON = buildFolderDepsJSON(files, scope.Keep, dict)
+		cd.folderDepsJSON = buildFolderDepsJSON(currentView.ConcernedFiles, currentView.FileDependencies, dict)
 
 		cd.dictionaryJSON = dict.ToJSON()
 
@@ -538,107 +537,14 @@ func buildLinterDataJS(eval *requirement.EvaluationResult) string {
 	return js.String()
 }
 
-// buildFileDepsJSON builds a JSON map of file dependency relationships keyed by path hash.
-func buildFileDepsJSON(files []*pb.File, keep fileFilter, dict *StringDictionary) string {
-	// Step 1: Build class qualified name -> file path lookup
-	classToFile := map[string]string{}
-	for _, f := range files {
-		if !keepFile(keep, f) {
-			continue
-		}
-		if f.Stmts == nil {
-			continue
-		}
-		classes := engine.GetClassesInFile(f)
-		for _, c := range classes {
-			if c.Name == nil {
-				continue
-			}
-			if q := c.Name.GetQualified(); q != "" {
-				classToFile[q] = f.Path
-			}
-			if s := c.Name.GetShort(); s != "" {
-				if _, exists := classToFile[s]; !exists {
-					classToFile[s] = f.Path
-				}
-			}
-		}
-	}
-
-	// Step 2: Build efferent map from StmtExternalDependencies
-	type depInfo struct {
-		path  string
-		short string
-	}
-	efferent := map[string]map[string]depInfo{}
-
-	for _, f := range files {
-		if !keepFile(keep, f) {
-			continue
-		}
-		if f.Stmts == nil {
-			continue
-		}
-
-		deps := f.Stmts.GetStmtExternalDependencies()
-		for _, ns := range f.Stmts.GetStmtNamespace() {
-			if ns != nil && ns.Stmts != nil {
-				deps = append(deps, ns.Stmts.GetStmtExternalDependencies()...)
-			}
-		}
-
-		for _, dep := range deps {
-			if dep == nil {
-				continue
-			}
-			targetFile := ""
-			if ns := dep.GetNamespace(); ns != "" {
-				if fp, ok := classToFile[ns]; ok {
-					targetFile = fp
-				}
-			}
-			if targetFile == "" {
-				if cn := dep.GetClassName(); cn != "" {
-					if fp, ok := classToFile[cn]; ok {
-						targetFile = fp
-					}
-				}
-			}
-			if targetFile == "" || targetFile == f.Path {
-				continue
-			}
-			if efferent[f.Path] == nil {
-				efferent[f.Path] = map[string]depInfo{}
-			}
-			short := targetFile
-			if idx := strings.LastIndex(targetFile, "/"); idx >= 0 {
-				short = targetFile[idx+1:]
-			}
-			efferent[f.Path][targetFile] = depInfo{path: targetFile, short: short}
-		}
-	}
-
-	// Step 3: Invert to get afferent
-	afferent := map[string]map[string]depInfo{}
-	for srcFile, targets := range efferent {
-		srcShort := srcFile
-		if idx := strings.LastIndex(srcFile, "/"); idx >= 0 {
-			srcShort = srcFile[idx+1:]
-		}
-		for tgtPath := range targets {
-			if afferent[tgtPath] == nil {
-				afferent[tgtPath] = map[string]depInfo{}
-			}
-			afferent[tgtPath][srcFile] = depInfo{path: srcFile, short: srcShort}
-		}
-	}
-
-	// Step 4: Collect all files that have any dependency
+// buildFileDepsJSON serializes the dependency graph computed by the analyzer.
+// It deliberately contains no language or import-resolution logic.
+func buildFileDepsJSON(graph analyzer.FileDependencyGraph, dict *StringDictionary) string {
 	allFiles := map[string]struct{}{}
-	for k := range efferent {
+	for k := range graph.Efferent {
 		allFiles[k] = struct{}{}
 	}
-	for k := range afferent {
+	for k := range graph.Afferent {
 		allFiles[k] = struct{}{}
 	}
 
@@ -646,26 +552,25 @@ func buildFileDepsJSON(files []*pb.File, keep fileFilter, dict *StringDictionary
 		return "{}"
 	}
 
-	// Step 5: Build struct map keyed by hash
 	result := make(map[string]fileDepsEntry, len(allFiles))
 	for fp := range allFiles {
 		entry := fileDepsEntry{
 			Efferent: make([]depRef, 0),
 			Afferent: make([]depRef, 0),
 		}
-		if eff, ok := efferent[fp]; ok {
-			for _, d := range eff {
+		if eff, ok := graph.Efferent[fp]; ok {
+			for _, target := range sortedStrings(eff) {
 				entry.Efferent = append(entry.Efferent, depRef{
-					Path:  dict.Add(d.path),
-					Short: d.short,
+					Path:  dict.Add(target),
+					Short: filepath.Base(target),
 				})
 			}
 		}
-		if aff, ok := afferent[fp]; ok {
-			for _, d := range aff {
+		if aff, ok := graph.Afferent[fp]; ok {
+			for _, source := range sortedStrings(aff) {
 				entry.Afferent = append(entry.Afferent, depRef{
-					Path:  dict.Add(d.path),
-					Short: d.short,
+					Path:  dict.Add(source),
+					Short: filepath.Base(source),
 				})
 			}
 		}
@@ -679,118 +584,63 @@ func buildFileDepsJSON(files []*pb.File, keep fileFilter, dict *StringDictionary
 	return string(data)
 }
 
-// buildFolderDepsJSON aggregates file-level dependencies to folder-level.
-// Keys are hashed via the dictionary.
-func buildFolderDepsJSON(files []*pb.File, keep fileFilter, dict *StringDictionary) string {
-	classToFile := map[string]string{}
-	for _, f := range files {
-		if !keepFile(keep, f) {
-			continue
-		}
-		if f.Stmts == nil {
-			continue
-		}
-		classes := engine.GetClassesInFile(f)
-		for _, c := range classes {
-			if c.Name == nil {
-				continue
-			}
-			if q := c.Name.GetQualified(); q != "" {
-				classToFile[q] = f.Path
-			}
-			if s := c.Name.GetShort(); s != "" {
-				if _, exists := classToFile[s]; !exists {
-					classToFile[s] = f.Path
-				}
-			}
-		}
-	}
+func sortedStrings(values []string) []string {
+	result := append([]string(nil), values...)
+	sort.Strings(result)
+	return result
+}
 
-	type edge struct {
-		src string
-		dst string
+func sortedMapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
 	}
-	var edges []edge
+	sort.Strings(keys)
+	return keys
+}
+
+// buildFolderDepsJSON projects the analyzer's file graph to folders.
+func buildFolderDepsJSON(files []*pb.File, graph analyzer.FileDependencyGraph, dict *StringDictionary) string {
 	filesByFolder := map[string]map[string]struct{}{}
 
 	for _, f := range files {
-		if !keepFile(keep, f) {
+		if f == nil || f.Stmts == nil {
 			continue
 		}
-		if f.Stmts == nil {
-			continue
-		}
-
-		srcDir := path.Dir(f.Path)
+		srcDir := filepath.Dir(f.Path)
 		if filesByFolder[srcDir] == nil {
 			filesByFolder[srcDir] = map[string]struct{}{}
 		}
 		filesByFolder[srcDir][f.Path] = struct{}{}
-
-		deps := f.Stmts.GetStmtExternalDependencies()
-		for _, ns := range f.Stmts.GetStmtNamespace() {
-			if ns != nil && ns.Stmts != nil {
-				deps = append(deps, ns.Stmts.GetStmtExternalDependencies()...)
-			}
-		}
-
-		for _, dep := range deps {
-			if dep == nil {
-				continue
-			}
-			targetFile := ""
-			if ns := dep.GetNamespace(); ns != "" {
-				if fp, ok := classToFile[ns]; ok {
-					targetFile = fp
-				}
-			}
-			if targetFile == "" {
-				if cn := dep.GetClassName(); cn != "" {
-					if fp, ok := classToFile[cn]; ok {
-						targetFile = fp
-					}
-				}
-			}
-			if targetFile == "" || targetFile == f.Path {
-				continue
-			}
-			edges = append(edges, edge{src: f.Path, dst: targetFile})
-		}
 	}
 
 	// Aggregate to folder level
-	type folderEdgeCount struct {
-		count int
-	}
-	folderEfferent := map[string]map[string]*folderEdgeCount{}
-	folderAfferent := map[string]map[string]*folderEdgeCount{}
+	folderEfferent := map[string]map[string]int{}
+	folderAfferent := map[string]map[string]int{}
 	folderFileCount := map[string]int{}
 
 	for dir, fset := range filesByFolder {
 		folderFileCount[dir] = len(fset)
 	}
 
-	for _, e := range edges {
-		srcDir := path.Dir(e.src)
-		dstDir := path.Dir(e.dst)
-		if srcDir == dstDir {
-			continue
-		}
-		if folderEfferent[srcDir] == nil {
-			folderEfferent[srcDir] = map[string]*folderEdgeCount{}
-		}
-		if folderEfferent[srcDir][dstDir] == nil {
-			folderEfferent[srcDir][dstDir] = &folderEdgeCount{}
-		}
-		folderEfferent[srcDir][dstDir].count++
+	for _, source := range sortedMapKeys(graph.Efferent) {
+		targets := graph.Efferent[source]
+		for _, target := range targets {
+			srcDir := filepath.Dir(source)
+			dstDir := filepath.Dir(target)
+			if srcDir == dstDir {
+				continue
+			}
+			if folderEfferent[srcDir] == nil {
+				folderEfferent[srcDir] = map[string]int{}
+			}
+			folderEfferent[srcDir][dstDir]++
 
-		if folderAfferent[dstDir] == nil {
-			folderAfferent[dstDir] = map[string]*folderEdgeCount{}
+			if folderAfferent[dstDir] == nil {
+				folderAfferent[dstDir] = map[string]int{}
+			}
+			folderAfferent[dstDir][srcDir]++
 		}
-		if folderAfferent[dstDir][srcDir] == nil {
-			folderAfferent[dstDir][srcDir] = &folderEdgeCount{}
-		}
-		folderAfferent[dstDir][srcDir].count++
 	}
 
 	allFolders := map[string]struct{}{}
@@ -811,24 +661,24 @@ func buildFolderDepsJSON(files []*pb.File, keep fileFilter, dict *StringDictiona
 		FilesByFolder: make(map[string][]string),
 	}
 
-	for dir := range allFolders {
+	for _, dir := range sortedMapKeys(allFolders) {
 		entry := folderDepsEntry{
 			Efferent: make([]folderDepRef, 0),
 			Afferent: make([]folderDepRef, 0),
 		}
 		if eff, ok := folderEfferent[dir]; ok {
-			for target, fe := range eff {
+			for _, target := range sortedMapKeys(eff) {
 				entry.Efferent = append(entry.Efferent, folderDepRef{
 					Path:  dict.Add(target),
-					Count: fe.count,
+					Count: eff[target],
 				})
 			}
 		}
 		if aff, ok := folderAfferent[dir]; ok {
-			for source, fe := range aff {
+			for _, source := range sortedMapKeys(aff) {
 				entry.Afferent = append(entry.Afferent, folderDepRef{
 					Path:  dict.Add(source),
-					Count: fe.count,
+					Count: aff[source],
 				})
 			}
 		}
@@ -842,7 +692,7 @@ func buildFolderDepsJSON(files []*pb.File, keep fileFilter, dict *StringDictiona
 		// filesByFolder
 		if fset, ok := filesByFolder[dir]; ok && len(fset) > 0 {
 			flist := make([]string, 0, len(fset))
-			for fp := range fset {
+			for _, fp := range sortedMapKeys(fset) {
 				flist = append(flist, dict.Add(fp))
 			}
 			payload.FilesByFolder[dict.Add(dir)] = flist
@@ -1135,6 +985,12 @@ func directoryScopeLabel(directory string) string {
 		}
 	}
 	return filepath.ToSlash(cleaned)
+}
+
+func cloneDependencyWithFrom(dependency *pb.StmtExternalDependency, from string) *pb.StmtExternalDependency {
+	clone := proto.Clone(dependency).(*pb.StmtExternalDependency)
+	clone.From = from
+	return clone
 }
 
 func (v *HtmlReportGenerator) RegisterFilters() {
@@ -1757,9 +1613,7 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 			if targetClass.Stmts != nil {
 				for _, dep := range targetClass.Stmts.StmtExternalDependencies {
 					if dep != nil {
-						depCopy := *dep
-						depCopy.From = className
-						classDeps = append(classDeps, &depCopy)
+						classDeps = append(classDeps, cloneDependencyWithFrom(dep, className))
 					}
 				}
 			}
@@ -1813,9 +1667,7 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 					if method.Stmts != nil {
 						for _, dep := range method.Stmts.StmtExternalDependencies {
 							if dep != nil {
-								depCopy := *dep
-								depCopy.From = className
-								classDeps = append(classDeps, &depCopy)
+								classDeps = append(classDeps, cloneDependencyWithFrom(dep, className))
 							}
 						}
 					}
@@ -1962,9 +1814,7 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 			if targetClass.Stmts != nil {
 				for _, dep := range targetClass.Stmts.StmtExternalDependencies {
 					if dep != nil {
-						depCopy := *dep
-						depCopy.From = className
-						classDeps = append(classDeps, &depCopy)
+						classDeps = append(classDeps, cloneDependencyWithFrom(dep, className))
 					}
 				}
 			}
@@ -2018,9 +1868,7 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 					if method.Stmts != nil {
 						for _, dep := range method.Stmts.StmtExternalDependencies {
 							if dep != nil {
-								depCopy := *dep
-								depCopy.From = className
-								classDeps = append(classDeps, &depCopy)
+								classDeps = append(classDeps, cloneDependencyWithFrom(dep, className))
 							}
 						}
 					}

--- a/internal/report/html_report_generator_test.go
+++ b/internal/report/html_report_generator_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	pb "github.com/ast-metrics/ast-metrics/pb"
 )
 
@@ -181,17 +182,7 @@ func TestBuildNodeToCommunityJSON_Empty(t *testing.T) {
 
 func TestBuildFileDepsJSON_EmptySlicesNotNull(t *testing.T) {
 	dict := NewStringDictionary()
-	// File with a class that references itself (self-dep should be skipped)
-	file := &pb.File{
-		Path:                "/tmp/a.go",
-		ProgrammingLanguage: "Golang",
-		Stmts: &pb.Stmts{
-			StmtClass: []*pb.StmtClass{
-				{Name: &pb.Name{Short: "Foo", Qualified: "pkg\\Foo"}},
-			},
-		},
-	}
-	raw := buildFileDepsJSON([]*pb.File{file}, nil, dict)
+	raw := buildFileDepsJSON(analyzer.FileDependencyGraph{}, dict)
 	if raw != "{}" {
 		t.Fatalf("expected empty json for no deps, got %s", raw)
 	}
@@ -199,28 +190,13 @@ func TestBuildFileDepsJSON_EmptySlicesNotNull(t *testing.T) {
 
 func TestBuildFileDepsJSON_HashedKeys(t *testing.T) {
 	dict := NewStringDictionary()
-	fileA := &pb.File{
-		Path:                "/tmp/a.go",
-		ProgrammingLanguage: "Golang",
-		Stmts: &pb.Stmts{
-			StmtClass: []*pb.StmtClass{
-				{Name: &pb.Name{Short: "Foo", Qualified: "pkg\\Foo"}},
-			},
-			StmtExternalDependencies: []*pb.StmtExternalDependency{
-				{ClassName: "Bar"},
-			},
-		},
+	fileA := "/tmp/a.go"
+	fileB := "/tmp/b.go"
+	graph := analyzer.FileDependencyGraph{
+		Efferent: map[string][]string{fileA: {fileB}},
+		Afferent: map[string][]string{fileB: {fileA}},
 	}
-	fileB := &pb.File{
-		Path:                "/tmp/b.go",
-		ProgrammingLanguage: "Golang",
-		Stmts: &pb.Stmts{
-			StmtClass: []*pb.StmtClass{
-				{Name: &pb.Name{Short: "Bar", Qualified: "pkg\\Bar"}},
-			},
-		},
-	}
-	raw := buildFileDepsJSON([]*pb.File{fileA, fileB}, nil, dict)
+	raw := buildFileDepsJSON(graph, dict)
 	if !json.Valid([]byte(raw)) {
 		t.Fatalf("invalid json: %s", raw)
 	}
@@ -261,7 +237,11 @@ func TestBuildFolderDepsJSON_HashedKeys(t *testing.T) {
 			},
 		},
 	}
-	raw := buildFolderDepsJSON([]*pb.File{fileA, fileB}, nil, dict)
+	graph := analyzer.FileDependencyGraph{
+		Efferent: map[string][]string{fileA.Path: {fileB.Path}},
+		Afferent: map[string][]string{fileB.Path: {fileA.Path}},
+	}
+	raw := buildFolderDepsJSON([]*pb.File{fileA, fileB}, graph, dict)
 	if raw == "" {
 		t.Fatalf("expected non-empty json for cross-folder deps")
 	}
@@ -284,6 +264,38 @@ func TestBuildFolderDepsJSON_HashedKeys(t *testing.T) {
 	dictJSON := dict.ToJSON()
 	if !json.Valid([]byte(dictJSON)) {
 		t.Fatalf("invalid dict json: %s", dictJSON)
+	}
+}
+
+func TestDependencyJSONIsDeterministic(t *testing.T) {
+	source := &pb.File{Path: "/tmp/source/a.ts", Stmts: &pb.Stmts{}}
+	targetB := &pb.File{Path: "/tmp/b/b.ts", Stmts: &pb.Stmts{}}
+	targetZ := &pb.File{Path: "/tmp/z/z.ts", Stmts: &pb.Stmts{}}
+	firstGraph := analyzer.FileDependencyGraph{
+		Efferent: map[string][]string{source.Path: {targetZ.Path, targetB.Path}},
+		Afferent: map[string][]string{
+			targetB.Path: {source.Path},
+			targetZ.Path: {source.Path},
+		},
+	}
+	secondGraph := analyzer.FileDependencyGraph{
+		Efferent: map[string][]string{source.Path: {targetB.Path, targetZ.Path}},
+		Afferent: map[string][]string{
+			targetZ.Path: {source.Path},
+			targetB.Path: {source.Path},
+		},
+	}
+
+	firstFiles := buildFileDepsJSON(firstGraph, NewStringDictionary())
+	secondFiles := buildFileDepsJSON(secondGraph, NewStringDictionary())
+	if firstFiles != secondFiles {
+		t.Fatalf("file dependency JSON depends on input order:\n%s\n%s", firstFiles, secondFiles)
+	}
+
+	firstFolders := buildFolderDepsJSON([]*pb.File{source, targetZ, targetB}, firstGraph, NewStringDictionary())
+	secondFolders := buildFolderDepsJSON([]*pb.File{targetB, source, targetZ}, secondGraph, NewStringDictionary())
+	if firstFolders != secondFolders {
+		t.Fatalf("folder dependency JSON depends on input order:\n%s\n%s", firstFolders, secondFolders)
 	}
 }
 

--- a/internal/report/language_pages_integration_test.go
+++ b/internal/report/language_pages_integration_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,8 +11,10 @@ import (
 	"github.com/ast-metrics/ast-metrics/internal/engine"
 	"github.com/ast-metrics/ast-metrics/internal/engine/csharp"
 	"github.com/ast-metrics/ast-metrics/internal/engine/java"
+	"github.com/ast-metrics/ast-metrics/internal/engine/typescript"
 	pb "github.com/ast-metrics/ast-metrics/pb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestLanguageURLSlug guards the URL-safe naming of per-language report files:
@@ -205,4 +208,41 @@ namespace App.Services
 	csPage, err := os.ReadFile(filepath.Join(reportDir, "index_CSharp.html"))
 	assert.Nil(t, err)
 	assert.True(t, strings.Contains(string(csPage), "C#"), "Display name stays C#")
+}
+
+func TestHtmlReportFullPipelineTypeScriptDependencies(t *testing.T) {
+	projectDir := t.TempDir()
+	sourcePath := filepath.Join(projectDir, "Foo.ts")
+	targetPath := filepath.Join(projectDir, "Bar.ts")
+	require.NoError(t, os.WriteFile(sourcePath, []byte("import { Bar } from './Bar';\nexport const foo = new Bar();\n"), 0o600))
+	require.NoError(t, os.WriteFile(targetPath, []byte("export class Bar {}\n"), 0o600))
+
+	runner := &typescript.TypeScriptRunner{}
+	source, err := runner.Parse(sourcePath)
+	require.NoError(t, err)
+	target, err := runner.Parse(targetPath)
+	require.NoError(t, err)
+	files := []*pb.File{source, target}
+	analyzer.AnalyzeFiles(files, nil)
+	project := analyzer.NewAggregator(files, nil).Aggregates()
+	assert.Equal(t, []string{targetPath}, project.Combined.FileDependencies.Efferent[sourcePath])
+	assert.Equal(t, []string{sourcePath}, project.Combined.FileDependencies.Afferent[targetPath])
+
+	reportDir := t.TempDir()
+	generator := NewHtmlReportGenerator(reportDir).(*HtmlReportGenerator)
+	_, err = generator.Generate(files, project)
+	require.NoError(t, err)
+	require.Contains(t, generator.langCache, "All")
+
+	data, err := os.ReadFile(filepath.Join(reportDir, "data", "data_All.js"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), generator.langCache["All"].fileDepsJSON)
+
+	var dependencies map[string]fileDepsEntry
+	require.NoError(t, json.Unmarshal([]byte(generator.langCache["All"].fileDepsJSON), &dependencies))
+	dictionary := NewStringDictionary()
+	sourceHash := dictionary.Add(sourcePath)
+	targetHash := dictionary.Add(targetPath)
+	assert.Equal(t, []depRef{{Path: targetHash, Short: "Bar.ts"}}, dependencies[sourceHash].Efferent)
+	assert.Equal(t, []depRef{{Path: sourceHash, Short: "Foo.ts"}}, dependencies[targetHash].Afferent)
 }

--- a/internal/scm/git_repository_test.go
+++ b/internal/scm/git_repository_test.go
@@ -1,7 +1,6 @@
 package scm
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,14 +11,10 @@ func TestFindGitRoot(t *testing.T) {
 	// Test case where .git directory is found
 	t.Run("finds .git directory", func(t *testing.T) {
 		// Setup a temporary directory with a .git directory inside
-		tmpDir, err := ioutil.TempDir("", "test")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir)
+		tmpDir := t.TempDir()
 
 		gitDir := filepath.Join(tmpDir, ".git")
-		err = os.Mkdir(gitDir, 0755)
+		err := os.Mkdir(gitDir, 0755)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -35,14 +30,11 @@ func TestFindGitRoot(t *testing.T) {
 
 	// Test case where no .git directory is found
 	t.Run("does not find .git directory", func(t *testing.T) {
-		// Setup a temporary directory without a .git directory
-		tmpDir, err := ioutil.TempDir("", "test")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir)
-
-		_, err = FindGitRoot(tmpDir)
+		// A temp directory may itself live below a repository (for example when
+		// TMPDIR points into a checkout), so use the filesystem root as the one
+		// path whose ancestors cannot contain another .git entry.
+		volumeRoot := filepath.VolumeName(os.TempDir()) + string(filepath.Separator)
+		_, err := FindGitRoot(volumeRoot)
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}


### PR DESCRIPTION
Resolving imports worked well for statically namespaced languages, but has issues for dynamic languages. This PR tries to  introduce a new way to deal with dependencies ; each langage has now is own resolver