### PR TITLE
fix(analyzer): make the analysis reproducible from one run to the next

### DIFF
--- a/internal/analyzer/aggregator.go
+++ b/internal/analyzer/aggregator.go
@@ -1,9 +1,11 @@
 package analyzer
 
 import (
+	"maps"
 	"math"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -327,21 +329,9 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 		chunks[i] = files[start:end]
 	}
 
-	// for each programming language, we create a separeted result
-	aggregateByLanguageChunk := make(map[string]Aggregated)
-	for _, file := range files {
-		if file.ProgrammingLanguage == "" {
-			continue
-		}
-		if _, ok := aggregateByLanguageChunk[file.ProgrammingLanguage]; !ok {
-			aggregateByLanguageChunk[file.ProgrammingLanguage] = newAggregated()
-		}
-	}
-
 	// for each analyzed path (CLI argument), we create a separated result. Only
 	// when several paths are analyzed: with a single one, the directory view
 	// would be a duplicate of the global view.
-	aggregateByDirectoryChunk := make(map[string]Aggregated)
 	directoryOfFile := make(map[*pb.File]string)
 	if len(r.AnalyzedPaths) > 1 {
 		scopes := buildAnalyzedPathScopes(r.AnalyzedPaths)
@@ -352,134 +342,85 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 					continue
 				}
 				directoryOfFile[file] = key
-				if _, exists := aggregateByDirectoryChunk[key]; !exists {
-					aggregateByDirectoryChunk[key] = newAggregated()
-				}
 			}
 		}
 	}
 
-	// Create channels for the results
-	resultsByClass := make(chan *Aggregated, numberOfProcessors)
-	resultsByFile := make(chan *Aggregated, numberOfProcessors)
-	resultsByProgrammingLanguage := make(chan *map[string]Aggregated, numberOfProcessors)
-	resultsByDirectory := make(chan *map[string]Aggregated, numberOfProcessors)
+	// Each worker owns its aggregates and writes them into its own slot: nothing
+	// is shared, so we get to choose the order in which they are merged back.
+	// That choice is what makes the analysis reproducible, since summing floats
+	// in the order the workers happen to finish would make the project totals
+	// wobble in their last bits from one run to the next.
+	partials := make([]chunkAggregates, numberOfProcessors)
 
-	// Deadlock prevention
-	mu := sync.Mutex{}
-
-	// Process each chunk of files
-	// Please ensure that there is no data race here. If needed, use the mutex
-	chunkIndex := 0
 	for i := 0; i < numberOfProcessors; i++ {
 
 		wg.Add(1)
 
 		// Reduce results : we want to get sums, and to count calculated values into a AggregateResult
-		go func(files []*pb.File) {
+		go func(slot int, files []*pb.File) {
 			defer wg.Done()
 
-			if len(files) == 0 {
-				return
-			}
-
-			// Prepare results
-			aggregateByFileChunk := newAggregated()
-			aggregateByClassChunk := newAggregated()
+			partial := newChunkAggregates()
 
 			// the process deal with its own chunk
 			for _, file := range files {
-				localFile := file
-
 				// by file
-				result := r.mapSums(localFile, aggregateByFileChunk)
-				result.ConcernedFiles = append(result.ConcernedFiles, localFile)
-				aggregateByFileChunk = result
+				byFile := r.mapSums(file, partial.byFile)
+				byFile.ConcernedFiles = append(byFile.ConcernedFiles, file)
+				partial.byFile = byFile
 
 				// by class
-				result = r.mapSums(localFile, aggregateByClassChunk)
-				result.ConcernedFiles = append(result.ConcernedFiles, localFile)
-				aggregateByClassChunk = result
+				byClass := r.mapSums(file, partial.byClass)
+				byClass.ConcernedFiles = append(byClass.ConcernedFiles, file)
+				partial.byClass = byClass
 
 				// by language, and by analyzed directory
-				mu.Lock()
-				byLanguage := r.mapSums(localFile, aggregateByLanguageChunk[localFile.ProgrammingLanguage])
-				byLanguage.ConcernedFiles = append(byLanguage.ConcernedFiles, localFile)
-				aggregateByLanguageChunk[localFile.ProgrammingLanguage] = byLanguage
-
-				if directory, ok := directoryOfFile[localFile]; ok {
-					byDirectory := r.mapSums(localFile, aggregateByDirectoryChunk[directory])
-					byDirectory.ConcernedFiles = append(byDirectory.ConcernedFiles, localFile)
-					aggregateByDirectoryChunk[directory] = byDirectory
+				r.addFileToBucket(partial.byLanguage, file.ProgrammingLanguage, file)
+				if directory, ok := directoryOfFile[file]; ok {
+					r.addFileToBucket(partial.byDirectory, directory, file)
 				}
-				mu.Unlock()
 			}
 
-			// Send the result to the channels
-			resultsByClass <- &aggregateByClassChunk
-			resultsByFile <- &aggregateByFileChunk
-			resultsByProgrammingLanguage <- &aggregateByLanguageChunk
-			resultsByDirectory <- &aggregateByDirectoryChunk
+			partials[slot] = partial
 
-		}(chunks[chunkIndex])
-		chunkIndex++
+		}(i, chunks[i])
 	}
 
 	wg.Wait()
-	close(resultsByClass)
-	close(resultsByFile)
-	close(resultsByProgrammingLanguage)
-	close(resultsByDirectory)
 
-	// Now we have chunk of sums. We want to reduce its into a single object
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for chunk := range resultsByClass {
-			r := r.mergeChunks(projectAggregated.ByClass, chunk)
-			projectAggregated.ByClass = r
-		}
-	}()
+	// Now we have chunk of sums. We want to reduce its into a single object,
+	// walking the chunks in index order rather than in completion order.
+	for i := range partials {
+		partial := partials[i]
+		projectAggregated.ByFile = r.mergeChunks(projectAggregated.ByFile, &partial.byFile)
+		projectAggregated.ByClass = r.mergeChunks(projectAggregated.ByClass, &partial.byClass)
+		r.mergeBuckets(projectAggregated.ByProgrammingLanguage, partial.byLanguage)
+		r.mergeBuckets(projectAggregated.ByDirectory, partial.byDirectory)
+	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for chunk := range resultsByFile {
-			r := r.mergeChunks(projectAggregated.ByFile, chunk)
-			projectAggregated.ByFile = r
-		}
-	}()
+	// Files were appended chunk by chunk. Canonicalize every aggregate before
+	// the coupling and test-quality analyzers consume these lists, since both
+	// index by a key several files can share and keep the last writer.
+	sortFilesByPath(projectAggregated.ByClass.ConcernedFiles)
+	sortFilesByPath(projectAggregated.ByFile.ConcernedFiles)
 
-	wg.Add(1)
-	go func() {
-		mu.Lock()
-		defer wg.Done()
-		defer mu.Unlock()
-
-		for chunk := range resultsByProgrammingLanguage {
-			for k, v := range *chunk {
-				projectAggregated.ByProgrammingLanguage[k] = v
-			}
-		}
-
-		for chunk := range resultsByDirectory {
-			for k, v := range *chunk {
-				projectAggregated.ByDirectory[k] = v
-			}
-		}
-	}()
-
-	wg.Wait()
-
-	// Now  we have sums. We want to reduce metrics and get the averages
+	// Now  we have sums. We want to reduce metrics and get the averages.
+	// mapCoupling writes back into the *pb.File it visits, so the buckets are
+	// walked by sorted key: with Go's map order, the values one bucket reads
+	// would depend on which buckets ran before it.
 	projectAggregated.ByClass = r.reduceMetrics(projectAggregated.ByClass)
 	projectAggregated.ByFile = r.reduceMetrics(projectAggregated.ByFile)
-	for k, v := range projectAggregated.ByProgrammingLanguage {
+	for _, k := range slices.Sorted(maps.Keys(projectAggregated.ByProgrammingLanguage)) {
+		v := projectAggregated.ByProgrammingLanguage[k]
+		sortFilesByPath(v.ConcernedFiles)
 		v = r.reduceMetrics(v)
 		f := r.mapCoupling(&v)
 		projectAggregated.ByProgrammingLanguage[k] = f
 	}
-	for k, v := range projectAggregated.ByDirectory {
+	for _, k := range slices.Sorted(maps.Keys(projectAggregated.ByDirectory)) {
+		v := projectAggregated.ByDirectory[k]
+		sortFilesByPath(v.ConcernedFiles)
 		v = r.reduceMetrics(v)
 		f := r.mapCoupling(&v)
 		projectAggregated.ByDirectory[k] = f
@@ -498,6 +439,62 @@ func (r *Aggregator) executeAggregationOnFiles(files []*pb.File) ProjectAggregat
 	riskAnalyzer.Analyze(projectAggregated)
 
 	return projectAggregated
+}
+
+// chunkAggregates holds the sums computed by a single worker over its own chunk
+// of files. Workers never share these, which is what lets the caller merge them
+// back in a fixed order.
+type chunkAggregates struct {
+	byFile      Aggregated
+	byClass     Aggregated
+	byLanguage  map[string]Aggregated
+	byDirectory map[string]Aggregated
+}
+
+func newChunkAggregates() chunkAggregates {
+	return chunkAggregates{
+		byFile:      newAggregated(),
+		byClass:     newAggregated(),
+		byLanguage:  make(map[string]Aggregated),
+		byDirectory: make(map[string]Aggregated),
+	}
+}
+
+// addFileToBucket sums a file into the named bucket, creating it on first use.
+func (r *Aggregator) addFileToBucket(buckets map[string]Aggregated, key string, file *pb.File) {
+	bucket, ok := buckets[key]
+	if !ok {
+		bucket = newAggregated()
+	}
+	bucket = r.mapSums(file, bucket)
+	bucket.ConcernedFiles = append(bucket.ConcernedFiles, file)
+	buckets[key] = bucket
+}
+
+// mergeBuckets folds one worker's named aggregates into the project ones.
+func (r *Aggregator) mergeBuckets(into map[string]Aggregated, from map[string]Aggregated) {
+	for key, bucket := range from {
+		base, ok := into[key]
+		if !ok {
+			base = newAggregated()
+		}
+		into[key] = r.mergeChunks(base, &bucket)
+	}
+}
+
+func sortFilesByPath(files []*pb.File) {
+	sort.SliceStable(files, func(i, j int) bool {
+		if files[i] == nil {
+			return false
+		}
+		if files[j] == nil {
+			return true
+		}
+		if files[i].Path != files[j].Path {
+			return files[i].Path < files[j].Path
+		}
+		return files[i].ProgrammingLanguage < files[j].ProgrammingLanguage
+	})
 }
 
 // Add an analyzer to the aggregator
@@ -933,7 +930,22 @@ func (r *Aggregator) mapSums(file *pb.File, specificAggregation Aggregated) Aggr
 	return result
 }
 
-// Merge the chunks of files to get the aggregated data (sums)
+// mergeAggregateResults folds a chunk result into an accumulator. Min is stored
+// with 0 meaning "not set yet", which is the convention mapSums uses.
+func mergeAggregateResults(into *AggregateResult, chunk AggregateResult) {
+	into.Sum += chunk.Sum
+	into.Counter += chunk.Counter
+	if into.Min == 0 || (chunk.Min > 0 && chunk.Min < into.Min) {
+		into.Min = chunk.Min
+	}
+	if chunk.Max > into.Max {
+		into.Max = chunk.Max
+	}
+}
+
+// mergeChunks merges the sums of one chunk into an accumulator. It has to cover
+// every field mapSums writes, otherwise the aggregates that go through it lose
+// what the ones built in a single pass keep.
 func (r *Aggregator) mergeChunks(aggregated Aggregated, chunk *Aggregated) Aggregated {
 
 	result := aggregated
@@ -945,95 +957,55 @@ func (r *Aggregator) mergeChunks(aggregated Aggregated, chunk *Aggregated) Aggre
 	result.NbMethods += chunk.NbMethods
 	result.NbFunctions += chunk.NbFunctions
 
-	result.Loc.Sum += chunk.Loc.Sum
-	result.Loc.Counter += chunk.Loc.Counter
-	result.TestLoc.Sum += chunk.TestLoc.Sum
-	result.TestLoc.Counter += chunk.TestLoc.Counter
-	result.Cloc.Sum += chunk.Cloc.Sum
-	result.Cloc.Counter += chunk.Cloc.Counter
-	result.Lloc.Sum += chunk.Lloc.Sum
-	result.Lloc.Counter += chunk.Lloc.Counter
+	mergeAggregateResults(&result.Loc, chunk.Loc)
+	mergeAggregateResults(&result.TestLoc, chunk.TestLoc)
+	mergeAggregateResults(&result.Cloc, chunk.Cloc)
+	mergeAggregateResults(&result.Lloc, chunk.Lloc)
 
-	result.MethodsPerClass.Sum += chunk.MethodsPerClass.Sum
-	result.MethodsPerClass.Counter += chunk.MethodsPerClass.Counter
-	result.LocPerClass.Sum += chunk.LocPerClass.Sum
-	result.LocPerClass.Counter += chunk.LocPerClass.Counter
-	result.LocPerMethod.Sum += chunk.LocPerMethod.Sum
-	result.LocPerMethod.Counter += chunk.LocPerMethod.Counter
-	result.LlocPerMethod.Sum += chunk.LlocPerMethod.Sum
-	result.LlocPerMethod.Counter += chunk.LlocPerMethod.Counter
-	result.ClocPerMethod.Sum += chunk.ClocPerMethod.Sum
-	result.ClocPerMethod.Counter += chunk.ClocPerMethod.Counter
-	result.CyclomaticComplexityPerMethod.Sum += chunk.CyclomaticComplexityPerMethod.Sum
-	result.CyclomaticComplexityPerMethod.Counter += chunk.CyclomaticComplexityPerMethod.Counter
-	if result.CyclomaticComplexityPerMethod.Min == 0 || (chunk.CyclomaticComplexityPerMethod.Min > 0 && chunk.CyclomaticComplexityPerMethod.Min < result.CyclomaticComplexityPerMethod.Min) {
-		result.CyclomaticComplexityPerMethod.Min = chunk.CyclomaticComplexityPerMethod.Min
-	}
-	if chunk.CyclomaticComplexityPerMethod.Max > result.CyclomaticComplexityPerMethod.Max {
-		result.CyclomaticComplexityPerMethod.Max = chunk.CyclomaticComplexityPerMethod.Max
-	}
+	mergeAggregateResults(&result.MethodsPerClass, chunk.MethodsPerClass)
+	mergeAggregateResults(&result.LocPerClass, chunk.LocPerClass)
+	mergeAggregateResults(&result.LocPerMethod, chunk.LocPerMethod)
+	mergeAggregateResults(&result.LlocPerMethod, chunk.LlocPerMethod)
+	mergeAggregateResults(&result.ClocPerMethod, chunk.ClocPerMethod)
 
-	result.CyclomaticComplexityPerClass.Sum += chunk.CyclomaticComplexityPerClass.Sum
-	result.CyclomaticComplexityPerClass.Counter += chunk.CyclomaticComplexityPerClass.Counter
+	mergeAggregateResults(&result.CyclomaticComplexity, chunk.CyclomaticComplexity)
+	mergeAggregateResults(&result.CyclomaticComplexityPerMethod, chunk.CyclomaticComplexityPerMethod)
+	mergeAggregateResults(&result.CyclomaticComplexityPerClass, chunk.CyclomaticComplexityPerClass)
 
-	result.CyclomaticComplexity.Sum += chunk.CyclomaticComplexity.Sum
-	result.CyclomaticComplexity.Counter += chunk.CyclomaticComplexity.Counter
-
-	result.HalsteadDifficulty.Sum += chunk.HalsteadDifficulty.Sum
-	result.HalsteadDifficulty.Counter += chunk.HalsteadDifficulty.Counter
-	result.HalsteadEffort.Sum += chunk.HalsteadEffort.Sum
-	result.HalsteadEffort.Counter += chunk.HalsteadEffort.Counter
-	result.HalsteadVolume.Sum += chunk.HalsteadVolume.Sum
-	result.HalsteadVolume.Counter += chunk.HalsteadVolume.Counter
-	result.HalsteadTime.Sum += chunk.HalsteadTime.Sum
-	result.HalsteadTime.Counter += chunk.HalsteadTime.Counter
-	result.HalsteadBugs.Sum += chunk.HalsteadBugs.Sum
-	result.HalsteadBugs.Counter += chunk.HalsteadBugs.Counter
-	if chunk.HalsteadBugs.Max > result.HalsteadBugs.Max {
-		result.HalsteadBugs.Max = chunk.HalsteadBugs.Max
-	}
+	mergeAggregateResults(&result.HalsteadDifficulty, chunk.HalsteadDifficulty)
+	mergeAggregateResults(&result.HalsteadEffort, chunk.HalsteadEffort)
+	mergeAggregateResults(&result.HalsteadVolume, chunk.HalsteadVolume)
+	mergeAggregateResults(&result.HalsteadTime, chunk.HalsteadTime)
+	mergeAggregateResults(&result.HalsteadBugs, chunk.HalsteadBugs)
 
 	// LCOM
-	result.Lcom4PerClass.Sum += chunk.Lcom4PerClass.Sum
-	result.Lcom4PerClass.Counter += chunk.Lcom4PerClass.Counter
-	if result.Lcom4PerClass.Min == 0 || (chunk.Lcom4PerClass.Min > 0 && chunk.Lcom4PerClass.Min < result.Lcom4PerClass.Min) {
-		result.Lcom4PerClass.Min = chunk.Lcom4PerClass.Min
-	}
-	if chunk.Lcom4PerClass.Max > result.Lcom4PerClass.Max {
-		result.Lcom4PerClass.Max = chunk.Lcom4PerClass.Max
-	}
+	mergeAggregateResults(&result.Lcom4PerClass, chunk.Lcom4PerClass)
 
-	result.MaintainabilityIndex.Sum += chunk.MaintainabilityIndex.Sum
-	result.MaintainabilityIndex.Counter += chunk.MaintainabilityIndex.Counter
-	if result.MaintainabilityIndex.Min == 0 || (chunk.MaintainabilityIndex.Min > 0 && chunk.MaintainabilityIndex.Min < result.MaintainabilityIndex.Min) {
-		result.MaintainabilityIndex.Min = chunk.MaintainabilityIndex.Min
-	}
-	if chunk.MaintainabilityIndex.Max > result.MaintainabilityIndex.Max {
-		result.MaintainabilityIndex.Max = chunk.MaintainabilityIndex.Max
-	}
-	result.MaintainabilityIndexWithoutComments.Sum += chunk.MaintainabilityIndexWithoutComments.Sum
-	result.MaintainabilityIndexWithoutComments.Counter += chunk.MaintainabilityIndexWithoutComments.Counter
-	result.MaintainabilityCommentWeight.Sum += chunk.MaintainabilityCommentWeight.Sum
-	result.MaintainabilityCommentWeight.Counter += chunk.MaintainabilityCommentWeight.Counter
+	mergeAggregateResults(&result.MaintainabilityIndex, chunk.MaintainabilityIndex)
+	mergeAggregateResults(&result.MaintainabilityIndexWithoutComments, chunk.MaintainabilityIndexWithoutComments)
+	mergeAggregateResults(&result.MaintainabilityCommentWeight, chunk.MaintainabilityCommentWeight)
 
-	result.EfferentCoupling.Sum += chunk.EfferentCoupling.Sum
-	result.EfferentCoupling.Counter += chunk.EfferentCoupling.Counter
-	result.AfferentCoupling.Sum += chunk.AfferentCoupling.Sum
-	result.AfferentCoupling.Counter += chunk.AfferentCoupling.Counter
+	mergeAggregateResults(&result.Instability, chunk.Instability)
+	mergeAggregateResults(&result.EfferentCoupling, chunk.EfferentCoupling)
+	mergeAggregateResults(&result.AfferentCoupling, chunk.AfferentCoupling)
 
-	result.MaintainabilityPerMethod.Sum += chunk.MaintainabilityPerMethod.Sum
-	result.MaintainabilityPerMethod.Counter += chunk.MaintainabilityPerMethod.Counter
-	result.MaintainabilityPerMethodWithoutComments.Sum += chunk.MaintainabilityPerMethodWithoutComments.Sum
-	result.MaintainabilityPerMethodWithoutComments.Counter += chunk.MaintainabilityPerMethodWithoutComments.Counter
-	result.MaintainabilityCommentWeightPerMethod.Sum += chunk.MaintainabilityCommentWeightPerMethod.Sum
-	result.MaintainabilityCommentWeightPerMethod.Counter += chunk.MaintainabilityCommentWeightPerMethod.Counter
+	mergeAggregateResults(&result.MaintainabilityPerMethod, chunk.MaintainabilityPerMethod)
+	mergeAggregateResults(&result.MaintainabilityPerMethodWithoutComments, chunk.MaintainabilityPerMethodWithoutComments)
+	mergeAggregateResults(&result.MaintainabilityCommentWeightPerMethod, chunk.MaintainabilityCommentWeightPerMethod)
 
 	result.CommitCountForPeriod += chunk.CommitCountForPeriod
 	result.CommittedFilesCountForPeriod += chunk.CommittedFilesCountForPeriod
 
-	result.PackageRelations = make(map[string]map[string]int)
-	for k, v := range chunk.PackageRelations {
-		result.PackageRelations[k] = v
+	if result.PackageRelations == nil {
+		result.PackageRelations = make(map[string]map[string]int)
+	}
+	for from, targets := range chunk.PackageRelations {
+		if result.PackageRelations[from] == nil {
+			result.PackageRelations[from] = make(map[string]int)
+		}
+		for to, count := range targets {
+			result.PackageRelations[from][to] += count
+		}
 	}
 
 	result.ErroredFiles = append(result.ErroredFiles, chunk.ErroredFiles...)

--- a/internal/analyzer/ast_analyzer.go
+++ b/internal/analyzer/ast_analyzer.go
@@ -14,6 +14,11 @@ import (
 	"github.com/pterm/pterm"
 )
 
+type analyzeJob struct {
+	index int
+	file  *pb.File
+}
+
 // AnalyzeFiles runs all metric visitors on pre-parsed in-memory files.
 func AnalyzeFiles(parsedFiles []*pb.File, progressbar *pterm.SpinnerPrinter) []*pb.File {
 	if len(parsedFiles) == 0 {
@@ -25,28 +30,30 @@ func AnalyzeFiles(parsedFiles []*pb.File, progressbar *pterm.SpinnerPrinter) []*
 	total := len(parsedFiles)
 
 	numWorkers := runtime.NumCPU()
-	filesChan := make(chan *pb.File, numWorkers)
-	resultChan := make(chan *pb.File, total)
+	filesChan := make(chan analyzeJob, numWorkers)
+	allResults := make([]*pb.File, total)
 
 	for i := 0; i < numWorkers; i++ {
 		go func() {
-			for file := range filesChan {
-				AnalyzeFile(file)
+			for job := range filesChan {
+				AnalyzeFile(job.file)
 
 				nbDone.Add(1)
 				if progressbar != nil {
 					details := strconv.Itoa(int(nbDone.Load())) + "/" + strconv.Itoa(total)
 					progressbar.UpdateText("Analyzing (" + details + ")")
 				}
-				resultChan <- file
+				// Each worker owns a distinct slot. This preserves the parser order
+				// even though analysis completes concurrently.
+				allResults[job.index] = job.file
 				wg.Done()
 			}
 		}()
 	}
 
-	for _, file := range parsedFiles {
+	for i, file := range parsedFiles {
 		wg.Add(1)
-		filesChan <- file
+		filesChan <- analyzeJob{index: i, file: file}
 	}
 
 	close(filesChan)
@@ -56,11 +63,6 @@ func AnalyzeFiles(parsedFiles []*pb.File, progressbar *pterm.SpinnerPrinter) []*
 		progressbar.Info("AST Analysis finished")
 	}
 
-	allResults := make([]*pb.File, 0, total)
-	for i := 0; i < total; i++ {
-		allResults = append(allResults, <-resultChan)
-	}
-	close(resultChan)
 	return allResults
 }
 

--- a/internal/analyzer/community_aggregator.go
+++ b/internal/analyzer/community_aggregator.go
@@ -2,6 +2,9 @@ package analyzer
 
 import (
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	graph "github.com/ast-metrics/ast-metrics/internal/analyzer/graph"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer/namer"
@@ -125,9 +128,17 @@ func computeModularityQ(g *pb.Graph, node2comm map[string]string) float64 {
 		return 0
 	}
 	twoM := 2.0 * m
-	// Precompute communities per node
+	// Precompute communities per node. The edges are summed in a fixed order:
+	// float addition is not associative, so walking the set in map order would
+	// move the last digits of Q from one run to the next.
+	orderedEdges := slices.SortedFunc(maps.Keys(edges), func(x, y pair) int {
+		if x.a != y.a {
+			return strings.Compare(x.a, y.a)
+		}
+		return strings.Compare(x.b, y.b)
+	})
 	Q := 0.0
-	for e := range edges {
+	for _, e := range orderedEdges {
 		ci := node2comm[e.a]
 		cj := node2comm[e.b]
 		if ci == "" || cj == "" {
@@ -254,7 +265,9 @@ func (ca *CommunityAggregator) Calculate(aggregate *Aggregated) {
 		// Rebuild communities and maxSize after merges
 		newComms := map[string][]string{}
 		newMax := 0
-		for u := range aggregate.Graph.Nodes {
+		// By node id rather than in map order: these lists are read as-is by
+		// the report and by the matrix ordering below.
+		for _, u := range slices.Sorted(maps.Keys(aggregate.Graph.Nodes)) {
 			c := node2comm[u]
 			if c == "" {
 				continue
@@ -623,12 +636,16 @@ func (ca *CommunityAggregator) Calculate(aggregate *Aggregated) {
 		}
 		visited := map[string]bool{}
 		seq := []string{}
+		// Communities and neighbours are walked by name rather than in map
+		// order: this produces a slice, so equal degrees have to be broken by
+		// something stable or the matrix comes out shuffled on every run.
+		orderedComms := slices.Sorted(maps.Keys(comms))
 		// multiple components: start from min-degree unvisited
 		for len(seq) < len(comms) {
 			// pick min-degree unvisited node
 			var start string
 			minD := 1 << 30
-			for c := range comms {
+			for _, c := range orderedComms {
 				if !visited[c] && deg[c] < minD {
 					minD = deg[c]
 					start = c
@@ -645,21 +662,19 @@ func (ca *CommunityAggregator) Calculate(aggregate *Aggregated) {
 				u := q[0]
 				q = q[1:]
 				comp = append(comp, u)
-				// neighbors sorted by degree
+				// neighbors sorted by degree, then by name
 				neigh := []string{}
 				for v := range und[u] {
 					if !visited[v] {
 						neigh = append(neigh, v)
 					}
 				}
-				// sort by degree asc
-				for i := 0; i < len(neigh); i++ {
-					for j := i + 1; j < len(neigh); j++ {
-						if deg[neigh[j]] < deg[neigh[i]] {
-							neigh[i], neigh[j] = neigh[j], neigh[i]
-						}
+				slices.SortFunc(neigh, func(a, b string) int {
+					if deg[a] != deg[b] {
+						return deg[a] - deg[b]
 					}
-				}
+					return strings.Compare(a, b)
+				})
 				for _, v := range neigh {
 					visited[v] = true
 					q = append(q, v)

--- a/internal/analyzer/graph/community_detection.go
+++ b/internal/analyzer/graph/community_detection.go
@@ -26,6 +26,13 @@ func undirectedAdj(g *pb.Graph) map[string][]string {
 			}
 		}
 	}
+	// g.Nodes is a map, so the neighbours land in an arbitrary order. The label
+	// histogram below sums 1/sqrt(deg) weights and compares them with ==, which
+	// makes it sensitive to the order the terms are added in: sort the lists so
+	// two runs on the same graph agree on the same communities.
+	for id := range adj {
+		slices.Sort(adj[id])
+	}
 	return adj
 }
 

--- a/internal/analyzer/graph_aggregator.go
+++ b/internal/analyzer/graph_aggregator.go
@@ -1,9 +1,12 @@
 package analyzer
 
 import (
+	"maps"
+	"slices"
+	"strings"
+
 	"github.com/ast-metrics/ast-metrics/internal/engine"
 	pb "github.com/ast-metrics/ast-metrics/pb"
-	"sort"
 )
 
 type GraphAggregator struct{}
@@ -104,10 +107,17 @@ func (ga *GraphAggregator) Calculate(aggregate *Aggregated) {
 		}
 		totalOut[fromNs] = sum
 	}
-	for fromNs, tos := range edgesCount {
+	// Sources and targets are walked in a fixed order: the edge list of a node is
+	// a slice, so letting Go's map iteration decide would give a different graph
+	// layout, and different community labels, on every run.
+	// Note that with absThreshold at 1 no candidate is ever filtered out, since
+	// an edge only exists once it has been counted at least once. The top-K and
+	// relative thresholds only start to bite if absThreshold is raised.
+	for _, fromNs := range slices.Sorted(maps.Keys(edgesCount)) {
+		tos := edgesCount[fromNs]
 		// ensure source node exists and is marked as package
 		ensureNode(fromNs, &pb.Name{Qualified: fromNs, Short: fromNs, Package: fromNs})
-		// collect and sort targets by weight desc
+		// collect and sort targets by weight desc, then by name to break ties
 		type pair struct {
 			to string
 			w  int
@@ -116,20 +126,25 @@ func (ga *GraphAggregator) Calculate(aggregate *Aggregated) {
 		for toNs, w := range tos {
 			arr = append(arr, pair{to: toNs, w: w})
 		}
-		sort.Slice(arr, func(i, j int) bool { return arr[i].w > arr[j].w })
-		kept := map[string]bool{}
+		slices.SortFunc(arr, func(a, b pair) int {
+			if a.w != b.w {
+				return b.w - a.w
+			}
+			return strings.Compare(a.to, b.to)
+		})
+		kept := make([]string, 0, len(arr))
 		for i, p := range arr {
 			if i < topK || p.w >= absThreshold || float64(p.w) >= relThreshold*float64(totalOut[fromNs]) {
-				kept[p.to] = true
+				kept = append(kept, p.to)
 			}
 			// always ensure target node exists for visibility even if edge filtered
 			ensureNode(p.to, &pb.Name{Qualified: p.to, Short: p.to, Package: p.to})
 		}
 		// fallback: if nothing kept but at least one candidate, keep the strongest edge
 		if len(kept) == 0 && len(arr) > 0 {
-			kept[arr[0].to] = true
+			kept = append(kept, arr[0].to)
 		}
-		for toNs := range kept {
+		for _, toNs := range kept {
 			addEdge(fromNs, toNs)
 		}
 	}

--- a/internal/analyzer/requirement/baseline.go
+++ b/internal/analyzer/requirement/baseline.go
@@ -42,10 +42,15 @@ type baselineKey struct {
 // relative `sources:` entry from the configuration file), and keeps the
 // generated baseline file portable across machines and CI runners.
 func newBaselineKey(rule, file, message string) baselineKey {
-	return baselineKey{Rule: rule, File: relativeToCwd(file), Message: message}
+	return baselineKey{Rule: rule, File: RelativeToCwd(file), Message: message}
 }
 
-func relativeToCwd(path string) string {
+// RelativeToCwd shortens an absolute path that lives under the working
+// directory. Everything a baseline records has to go through it: a path is what
+// makes an entry recognizable from one run to the next, and an absolute one ties
+// the file to the machine that produced it, so a baseline generated in a
+// container would match nothing on the host or in CI.
+func RelativeToCwd(path string) string {
 	if path == "" || !filepath.IsAbs(path) {
 		return path
 	}

--- a/internal/analyzer/testquality_aggregator.go
+++ b/internal/analyzer/testquality_aggregator.go
@@ -10,20 +10,36 @@ import (
 	pb "github.com/ast-metrics/ast-metrics/pb"
 )
 
+// TopTestQualityListSize is how many god tests and orphan classes a report
+// shows. It is a display budget, not an analysis one: the lists below are
+// complete, so a lint rule sees every violation and a fixed one never promotes
+// the next offender into a "new" violation.
+const TopTestQualityListSize = 20
+
+// Top returns the head of a list, for a caller that displays it.
+func Top[T any](items []T) []T {
+	if len(items) > TopTestQualityListSize {
+		return items[:TopTestQualityListSize]
+	}
+	return items
+}
+
 // TestQualityMetrics holds all computed KPIs for test quality analysis
 type TestQualityMetrics struct {
 	GlobalIsolationScore float64
 	IsolationLabel       string
 	TestFiles            []TestFileMetrics
-	GodTests             []TestFileMetrics
-	OrphanClasses        []OrphanClass
-	ProdClassCoverage    []ProdClassCoverage
-	IsolationHistogram   [5]int // bins: 0-19, 20-39, 40-59, 60-79, 80-100
-	NbTestFiles          int
-	NbProdFiles          int
-	NbProdClasses        int
-	NbTestedClasses      int
-	TraceabilityPct      float64 // percentage of prod classes covered by at least one test
+	// GodTests and OrphanClasses hold every offender, worst first. Use Top to
+	// cut them down when displaying.
+	GodTests           []TestFileMetrics
+	OrphanClasses      []OrphanClass
+	ProdClassCoverage  []ProdClassCoverage
+	IsolationHistogram [5]int // bins: 0-19, 20-39, 40-59, 60-79, 80-100
+	NbTestFiles        int
+	NbProdFiles        int
+	NbProdClasses      int
+	NbTestedClasses    int
+	TraceabilityPct    float64 // percentage of prod classes covered by at least one test
 }
 
 // TestFileMetrics holds per-test-file metrics
@@ -38,22 +54,22 @@ type TestFileMetrics struct {
 
 // ProdClassCoverage holds per-prod-class test coverage metrics
 type ProdClassCoverage struct {
-	ClassName string
-	FilePath  string
-	TestCount int
+	ClassName  string
+	FilePath   string
+	TestCount  int
 	Complexity int32
-	Efferent  int32
-	Afferent  int32
+	Efferent   int32
+	Afferent   int32
 }
 
 // OrphanClass is a production class with zero tests, weighted by importance
 type OrphanClass struct {
-	ClassName string
-	FilePath  string
+	ClassName  string
+	FilePath   string
 	Complexity int32
-	Efferent  int32
-	Afferent  int32
-	Weight    float64
+	Efferent   int32
+	Afferent   int32
+	Weight     float64
 }
 
 // TestQualityAggregator computes test quality metrics
@@ -236,6 +252,12 @@ func (tqa *TestQualityAggregator) Calculate(aggregate *Aggregated) {
 		}
 	}
 
+	sort.Slice(allTestMetrics, func(i, j int) bool {
+		if allTestMetrics[i].FilePath != allTestMetrics[j].FilePath {
+			return allTestMetrics[i].FilePath < allTestMetrics[j].FilePath
+		}
+		return allTestMetrics[i].ShortPath < allTestMetrics[j].ShortPath
+	})
 	metrics.TestFiles = allTestMetrics
 
 	// 5. Build ProdClassCoverage
@@ -276,13 +298,19 @@ func (tqa *TestQualityAggregator) Calculate(aggregate *Aggregated) {
 			testedCount++
 		}
 	}
+	sort.Slice(prodCoverage, func(i, j int) bool {
+		if prodCoverage[i].ClassName != prodCoverage[j].ClassName {
+			return prodCoverage[i].ClassName < prodCoverage[j].ClassName
+		}
+		return prodCoverage[i].FilePath < prodCoverage[j].FilePath
+	})
 	metrics.ProdClassCoverage = prodCoverage
 	metrics.NbTestedClasses = testedCount
 	if len(prodClassIndex) > 0 {
 		metrics.TraceabilityPct = float64(testedCount) / float64(len(prodClassIndex)) * 100
 	}
 
-	// 6. God Tests: fan-out >= 5, top 20
+	// 6. God Tests: fan-out >= 5, worst first
 	var godTests []TestFileMetrics
 	for _, t := range allTestMetrics {
 		if t.SUTFanOut >= 5 {
@@ -290,14 +318,17 @@ func (tqa *TestQualityAggregator) Calculate(aggregate *Aggregated) {
 		}
 	}
 	sort.Slice(godTests, func(i, j int) bool {
-		return godTests[i].SUTFanOut > godTests[j].SUTFanOut
+		if godTests[i].SUTFanOut != godTests[j].SUTFanOut {
+			return godTests[i].SUTFanOut > godTests[j].SUTFanOut
+		}
+		if godTests[i].FilePath != godTests[j].FilePath {
+			return godTests[i].FilePath < godTests[j].FilePath
+		}
+		return godTests[i].ShortPath < godTests[j].ShortPath
 	})
-	if len(godTests) > 20 {
-		godTests = godTests[:20]
-	}
 	metrics.GodTests = godTests
 
-	// 7. Orphan Classes: TestCount == 0, sorted by weight desc, top 20
+	// 7. Orphan Classes: TestCount == 0, sorted by weight desc
 	var orphans []OrphanClass
 	for _, pc := range prodCoverage {
 		if pc.TestCount == 0 {
@@ -316,11 +347,14 @@ func (tqa *TestQualityAggregator) Calculate(aggregate *Aggregated) {
 		}
 	}
 	sort.Slice(orphans, func(i, j int) bool {
-		return orphans[i].Weight > orphans[j].Weight
+		if orphans[i].Weight != orphans[j].Weight {
+			return orphans[i].Weight > orphans[j].Weight
+		}
+		if orphans[i].ClassName != orphans[j].ClassName {
+			return orphans[i].ClassName < orphans[j].ClassName
+		}
+		return orphans[i].FilePath < orphans[j].FilePath
 	})
-	if len(orphans) > 20 {
-		orphans = orphans[:20]
-	}
 	metrics.OrphanClasses = orphans
 
 	// 8. Compute global isolation score (avg) and histogram
@@ -383,17 +417,17 @@ func isolationLabel(score float64) string {
 
 // testQualityJSON is the JSON-serializable representation of TestQualityMetrics
 type testQualityJSON struct {
-	GlobalIsolationScore float64            `json:"globalIsolationScore"`
-	IsolationLabel       string             `json:"isolationLabel"`
-	NbTestFiles          int                `json:"nbTestFiles"`
-	NbProdFiles          int                `json:"nbProdFiles"`
-	NbProdClasses        int                `json:"nbProdClasses"`
-	NbTestedClasses      int                `json:"nbTestedClasses"`
-	TraceabilityPct      float64            `json:"traceabilityPct"`
-	IsolationHistogram   [5]int             `json:"isolationHistogram"`
-	TestFiles            []testFileJSON     `json:"testFiles"`
-	GodTests             []godTestJSON      `json:"godTests"`
-	OrphanClasses        []orphanClassJSON  `json:"orphanClasses"`
+	GlobalIsolationScore float64           `json:"globalIsolationScore"`
+	IsolationLabel       string            `json:"isolationLabel"`
+	NbTestFiles          int               `json:"nbTestFiles"`
+	NbProdFiles          int               `json:"nbProdFiles"`
+	NbProdClasses        int               `json:"nbProdClasses"`
+	NbTestedClasses      int               `json:"nbTestedClasses"`
+	TraceabilityPct      float64           `json:"traceabilityPct"`
+	IsolationHistogram   [5]int            `json:"isolationHistogram"`
+	TestFiles            []testFileJSON    `json:"testFiles"`
+	GodTests             []godTestJSON     `json:"godTests"`
+	OrphanClasses        []orphanClassJSON `json:"orphanClasses"`
 }
 
 type testFileJSON struct {
@@ -447,8 +481,10 @@ func BuildTestQualityJSON(tq *TestQualityMetrics) string {
 		}
 	}
 
-	godTests := make([]godTestJSON, len(tq.GodTests))
-	for i, t := range tq.GodTests {
+	// The report shows the head of each list, the metrics keep them whole.
+	topGodTests := Top(tq.GodTests)
+	godTests := make([]godTestJSON, len(topGodTests))
+	for i, t := range topGodTests {
 		godTests[i] = godTestJSON{
 			ShortPath:      t.ShortPath,
 			FanOut:         t.SUTFanOut,
@@ -457,8 +493,9 @@ func BuildTestQualityJSON(tq *TestQualityMetrics) string {
 		}
 	}
 
-	orphans := make([]orphanClassJSON, len(tq.OrphanClasses))
-	for i, o := range tq.OrphanClasses {
+	topOrphans := Top(tq.OrphanClasses)
+	orphans := make([]orphanClassJSON, len(topOrphans))
+	for i, o := range topOrphans {
 		orphans[i] = orphanClassJSON{
 			ClassName:  o.ClassName,
 			FilePath:   o.FilePath,

--- a/internal/analyzer/testquality_aggregator_test.go
+++ b/internal/analyzer/testquality_aggregator_test.go
@@ -1,6 +1,8 @@
 package analyzer
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	pb "github.com/ast-metrics/ast-metrics/pb"
@@ -177,10 +179,10 @@ func TestTestQualityAggregator_GodTestDetection(t *testing.T) {
 
 func TestTestQualityAggregator_IsolationScoreTiers(t *testing.T) {
 	tests := []struct {
-		fanOut         int
-		expectedLabel  string
-		minScore       float64
-		maxScore       float64
+		fanOut        int
+		expectedLabel string
+		minScore      float64
+		maxScore      float64
 	}{
 		{0, "Isolated", 100, 100},
 		{1, "Isolated", 85, 95},
@@ -279,6 +281,65 @@ func TestTestQualityAggregator_OrphanDetection(t *testing.T) {
 	// ImportantService should be first (higher weight)
 	assert.Equal(t, "ImportantService", agg.TestQuality.OrphanClasses[0].ClassName)
 	assert.Greater(t, agg.TestQuality.OrphanClasses[0].Weight, agg.TestQuality.OrphanClasses[1].Weight)
+}
+
+func TestTestQualityAggregator_TopListsBreakTiesDeterministically(t *testing.T) {
+	agg := newAggregated()
+
+	// More than TopTestQualityListSize equal-weight orphans and equal-fan-out
+	// god tests: the lists are complete, and equals are ordered by name so the
+	// display cut always falls at the same place.
+	classes := make([]*pb.StmtClass, 0, 30)
+	for i := 0; i < 30; i++ {
+		name := fmt.Sprintf("Class%02d", i)
+		complexity := int32(1)
+		classes = append(classes, &pb.StmtClass{
+			Name: &pb.Name{Qualified: name, Short: name},
+			Stmts: &pb.Stmts{Analyze: &pb.Analyze{
+				Complexity: &pb.Complexity{Cyclomatic: &complexity},
+			}},
+		})
+	}
+
+	prodFile := &pb.File{
+		Path:                "src/classes.go",
+		ProgrammingLanguage: "Go",
+		Stmts:               &pb.Stmts{StmtClass: classes},
+	}
+	agg.ConcernedFiles = append(agg.ConcernedFiles, prodFile)
+
+	deps := make([]*pb.StmtExternalDependency, 0, 5)
+	for i := 0; i < 5; i++ {
+		deps = append(deps, &pb.StmtExternalDependency{ClassName: fmt.Sprintf("Class%02d", i)})
+	}
+	// Reverse input order to prove that equal fan-out does not inherit parser
+	// completion order.
+	for i := 24; i >= 0; i-- {
+		path := fmt.Sprintf("tests/test%02d_test.go", i)
+		agg.ConcernedFiles = append(agg.ConcernedFiles, &pb.File{
+			Path:                path,
+			ShortPath:           filepath.Base(path),
+			ProgrammingLanguage: "Go",
+			IsTest:              true,
+			Stmts:               &pb.Stmts{StmtExternalDependencies: deps},
+		})
+	}
+
+	NewTestQualityAggregator().Calculate(&agg)
+
+	// Every offender is reported: a rule that only saw the first twenty would
+	// promote the twenty-first into a "new" violation as soon as one is fixed.
+	// Class00 to Class04 are the ones the tests touch, the 25 others are orphans.
+	assert.Len(t, agg.TestQuality.GodTests, 25)
+	assert.Len(t, agg.TestQuality.OrphanClasses, 25)
+	for i := 0; i < 25; i++ {
+		assert.Equal(t, fmt.Sprintf("tests/test%02d_test.go", i), agg.TestQuality.GodTests[i].FilePath)
+		assert.Equal(t, fmt.Sprintf("Class%02d", i+5), agg.TestQuality.OrphanClasses[i].ClassName)
+	}
+
+	// Reports take the head of the list, and always the same one.
+	assert.Len(t, Top(agg.TestQuality.GodTests), TopTestQualityListSize)
+	assert.Equal(t, "tests/test19_test.go", Top(agg.TestQuality.GodTests)[TopTestQualityListSize-1].FilePath)
 }
 
 func TestBuildTestQualityJSON(t *testing.T) {

--- a/internal/command/analyze_command.go
+++ b/internal/command/analyze_command.go
@@ -272,16 +272,20 @@ func buildProjectContext(pa analyzer.ProjectAggregated) ruleset.ProjectContext {
 	}
 	ctx.TraceabilityPct = tq.TraceabilityPct
 	ctx.GlobalIsolationScore = tq.GlobalIsolationScore
+	// Project rules name the offending file inside their message, and the
+	// baseline recognizes an entry by that message. Paths are made relative
+	// here, at the boundary, so a baseline survives moving between the host, a
+	// container and CI.
 	for _, gt := range tq.GodTests {
 		ctx.GodTests = append(ctx.GodTests, ruleset.GodTestInfo{
-			FilePath: gt.FilePath,
+			FilePath: requirement.RelativeToCwd(gt.FilePath),
 			FanOut:   gt.SUTFanOut,
 		})
 	}
 	for _, oc := range tq.OrphanClasses {
 		ctx.OrphanClasses = append(ctx.OrphanClasses, ruleset.OrphanClassInfo{
 			ClassName: oc.ClassName,
-			FilePath:  oc.FilePath,
+			FilePath:  requirement.RelativeToCwd(oc.FilePath),
 			Weight:    oc.Weight,
 		})
 	}

--- a/internal/command/determinism_test.go
+++ b/internal/command/determinism_test.go
@@ -1,0 +1,363 @@
+package command
+
+// Analyzing the same sources twice must give the same answer. The pipeline
+// parses, analyzes and aggregates on runtime.NumCPU() goroutines, and several
+// stages index by a key that many files share, or sum floats, or truncate a
+// sorted list: any of those turns "the order the workers happened to finish in"
+// into a visible difference in the output.
+//
+// Both tests below run the real pipeline several times over the same corpus and
+// require identical results. They re-parse on every run, because the analyzers
+// write back into the *pb.File they visit: replaying the aggregation on the
+// same in-memory tree would not measure anything.
+//
+// The corpus is built so the fragile paths are actually taken: dozens of
+// classes share the same orphan weight, dozens of test files share the same
+// fan-out, and both lists are longer than the top-20 the testing rules read, so
+// the cut falls inside a group of equals.
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ast-metrics/ast-metrics/internal/analyzer"
+	"github.com/ast-metrics/ast-metrics/internal/configuration"
+	"github.com/ast-metrics/ast-metrics/internal/engine"
+	"github.com/ast-metrics/ast-metrics/internal/engine/php"
+	"github.com/ast-metrics/ast-metrics/internal/storage"
+	pb "github.com/ast-metrics/ast-metrics/pb"
+)
+
+const (
+	determinismRuns          = 5
+	determinismProdClasses   = 60
+	determinismTestFiles     = 30
+	determinismTestFanOut    = 6
+	determinismDuplicateName = 4
+)
+
+func TestBaselineGenerationIsReproducible(t *testing.T) {
+	srcDir, testDir := writeDeterminismCorpus(t)
+
+	var first []byte
+	for run := range determinismRuns {
+		got := generateBaseline(t, srcDir, testDir, run)
+		if run == 0 {
+			first = got
+			continue
+		}
+		if string(got) != string(first) {
+			t.Fatalf("run %d produced a different baseline:\n%s", run, firstDifference(string(first), string(got)))
+		}
+	}
+
+	// A baseline that captured nothing would pass the comparison above without
+	// proving anything.
+	if !strings.Contains(string(first), "max_orphan_weight") || !strings.Contains(string(first), "max_god_test_fan_out") {
+		t.Fatalf("the corpus did not trigger the project-level rules, the test proves nothing:\n%s", first)
+	}
+}
+
+func TestProjectAggregatesAreReproducible(t *testing.T) {
+	srcDir, testDir := writeDeterminismCorpus(t)
+
+	var first string
+	for run := range determinismRuns {
+		got := snapshotProject(aggregateCorpus(t, srcDir, testDir))
+		if run == 0 {
+			first = got
+			continue
+		}
+		if got != first {
+			t.Fatalf("run %d produced different aggregates:\n%s", run, firstDifference(first, got))
+		}
+	}
+}
+
+// writeDeterminismCorpus lays out a small PHP project in two directories, so
+// that the per-directory aggregates are exercised too.
+func writeDeterminismCorpus(t *testing.T) (srcDir, testDir string) {
+	t.Helper()
+
+	root := t.TempDir()
+	srcDir = filepath.Join(root, "src")
+	testDir = filepath.Join(root, "tests")
+	for _, dir := range []string{srcDir, testDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("cannot create %s: %v", dir, err)
+		}
+	}
+
+	// Production classes. The complexity only takes three values, so around
+	// twenty classes share each orphan weight and the top-20 cut lands in the
+	// middle of a tie.
+	for i := range determinismProdClasses {
+		name := fmt.Sprintf("Service%02d", i)
+		var body strings.Builder
+		for branch := range 2 + i%3 {
+			fmt.Fprintf(&body, "        if ($x === %d) {\n            return %d;\n        }\n", branch, branch)
+		}
+		write(t, filepath.Join(srcDir, name+".php"), fmt.Sprintf(`<?php
+
+namespace App\Domain;
+
+class %s
+{
+    public function handle(int $x): int
+    {
+%s        return -1;
+    }
+}
+`, name, body.String()))
+	}
+
+	// Several files declaring the same qualified class name. The test-quality
+	// index keeps one entry per name, so whichever file is visited last wins.
+	for i := range determinismDuplicateName {
+		write(t, filepath.Join(srcDir, fmt.Sprintf("Duplicated%02d.php", i)), fmt.Sprintf(`<?php
+
+namespace App\Domain;
+
+class Duplicated
+{
+    public function handle(int $x): int
+    {
+        if ($x === %d) {
+            return %d;
+        }
+        return -1;
+    }
+}
+`, i, i))
+	}
+
+	// Test files, all with the same fan-out, and more of them than the top-20
+	// god test list can hold.
+	for i := range determinismTestFiles {
+		var uses, calls strings.Builder
+		for j := range determinismTestFanOut {
+			target := fmt.Sprintf("Service%02d", (i*determinismTestFanOut+j)%determinismProdClasses)
+			fmt.Fprintf(&uses, "use App\\Domain\\%s;\n", target)
+			fmt.Fprintf(&calls, "        $sut%d = new %s();\n", j, target)
+		}
+		name := fmt.Sprintf("Service%02dTest", i)
+		write(t, filepath.Join(testDir, name+".php"), fmt.Sprintf(`<?php
+
+namespace App\Tests;
+
+%s
+class %s extends \PHPUnit\Framework\TestCase
+{
+    public function testItRuns(): void
+    {
+%s    }
+}
+`, uses.String(), name, calls.String()))
+	}
+
+	return srcDir, testDir
+}
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("cannot write %s: %v", path, err)
+	}
+}
+
+// determinismConfiguration returns a configuration whose thresholds are low
+// enough that every rule under test reports something.
+func determinismConfiguration(t *testing.T, srcDir, testDir string) *configuration.Configuration {
+	t.Helper()
+
+	work := storage.Default()
+	work.Purge()
+	work.Ensure()
+
+	cfg := configuration.NewConfiguration()
+	cfg.Storage = work
+	cfg.SourcesToAnalyzePath = []string{srcDir, testDir}
+	cfg.Requirements = configuration.NewConfigurationRequirements()
+
+	intOf := func(i int) *int { return &i }
+	floatOf := func(f float64) *float64 { return &f }
+	cfg.Requirements.Rules.Volume.Loc = intOf(1)
+	cfg.Requirements.Rules.Complexity.Cyclomatic = intOf(1)
+	cfg.Requirements.Rules.Testing = &configuration.ConfigurationTestingRules{
+		MinTraceability:   intOf(90),
+		MinIsolationScore: intOf(90),
+		MaxGodTestFanOut:  intOf(determinismTestFanOut - 1),
+		MaxOrphanWeight:   floatOf(1),
+	}
+
+	return cfg
+}
+
+func generateBaseline(t *testing.T, srcDir, testDir string, run int) []byte {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), fmt.Sprintf("baseline-%d.yaml", run))
+	// A fresh runner on every run: the engine caches its file list, and reusing
+	// one would hide any instability in the discovery order.
+	cmd := NewBaselineCommand(determinismConfiguration(t, srcDir, testDir), bufio.NewWriter(os.Stdout), []engine.Engine{&php.PhpRunner{}})
+	cmd.Path = path
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run %d: %v", run, err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("run %d: baseline was not written: %v", run, err)
+	}
+	return data
+}
+
+func aggregateCorpus(t *testing.T, srcDir, testDir string) analyzer.ProjectAggregated {
+	t.Helper()
+
+	cfg := determinismConfiguration(t, srcDir, testDir)
+	runner := &php.PhpRunner{}
+	runner.SetConfiguration(cfg)
+	if err := runner.Ensure(); err != nil {
+		t.Fatalf("cannot prepare the PHP engine: %v", err)
+	}
+	parsed := runner.DumpAST()
+	if err := runner.Finish(); err != nil {
+		t.Fatalf("cannot finish the PHP engine: %v", err)
+	}
+	if len(parsed) == 0 {
+		t.Fatalf("no file was parsed, the corpus is not where the engine looks")
+	}
+
+	aggregator := analyzer.NewAggregator(analyzer.AnalyzeFiles(parsed, nil), nil)
+	aggregator.WithAnalyzedPaths(cfg.SourcesToAnalyzePath)
+	return aggregator.Aggregates()
+}
+
+// snapshotProject renders everything the reports and the rules read, in a form
+// where a single differing bit shows up as a differing line.
+func snapshotProject(pa analyzer.ProjectAggregated) string {
+	var sb strings.Builder
+	snapshotAggregated(&sb, "byFile", pa.ByFile)
+	snapshotAggregated(&sb, "byClass", pa.ByClass)
+	for _, key := range sortedKeysOf(pa.ByProgrammingLanguage) {
+		snapshotAggregated(&sb, "byLanguage["+key+"]", pa.ByProgrammingLanguage[key])
+	}
+	for _, key := range sortedKeysOf(pa.ByDirectory) {
+		snapshotAggregated(&sb, "byDirectory["+key+"]", pa.ByDirectory[key])
+	}
+	return sb.String()
+}
+
+func snapshotAggregated(sb *strings.Builder, prefix string, a analyzer.Aggregated) {
+	// Reflection rather than a hand-written list, so a metric added later is
+	// covered without anyone having to remember this file.
+	value := reflect.ValueOf(a)
+	for i, field := range reflect.VisibleFields(value.Type()) {
+		if !field.IsExported() {
+			continue
+		}
+		switch typed := value.Field(i).Interface().(type) {
+		case analyzer.AggregateResult:
+			fmt.Fprintf(sb, "%s.%s sum=%v min=%v max=%v avg=%v n=%d\n", prefix, field.Name, typed.Sum, typed.Min, typed.Max, typed.Avg, typed.Counter)
+		case int:
+			fmt.Fprintf(sb, "%s.%s=%d\n", prefix, field.Name, typed)
+		case float64:
+			fmt.Fprintf(sb, "%s.%s=%v\n", prefix, field.Name, typed)
+		}
+	}
+
+	for i, file := range a.ConcernedFiles {
+		fmt.Fprintf(sb, "%s.file[%d]=%s %s\n", prefix, i, file.GetPath(), snapshotCoupling(file))
+	}
+
+	if a.Graph != nil {
+		for _, id := range sortedKeysOf(a.Graph.Nodes) {
+			fmt.Fprintf(sb, "%s.node[%s]=%s\n", prefix, id, strings.Join(a.Graph.Nodes[id].GetEdges(), ","))
+		}
+	}
+
+	for _, source := range sortedKeysOf(a.FileDependencies.Efferent) {
+		fmt.Fprintf(sb, "%s.efferent[%s]=%s\n", prefix, source, strings.Join(a.FileDependencies.Efferent[source], ","))
+	}
+	for _, target := range sortedKeysOf(a.FileDependencies.Afferent) {
+		fmt.Fprintf(sb, "%s.afferent[%s]=%s\n", prefix, target, strings.Join(a.FileDependencies.Afferent[target], ","))
+	}
+
+	snapshotTestQuality(sb, prefix, a.TestQuality)
+	snapshotCommunity(sb, prefix, a.Community)
+}
+
+func snapshotCoupling(file *pb.File) string {
+	coupling := file.GetStmts().GetAnalyze().GetCoupling()
+	if coupling == nil {
+		return "coupling=none"
+	}
+	return fmt.Sprintf("afferent=%d efferent=%d instability=%v", coupling.GetAfferent(), coupling.GetEfferent(), coupling.GetInstability())
+}
+
+func snapshotTestQuality(sb *strings.Builder, prefix string, tq *analyzer.TestQualityMetrics) {
+	if tq == nil {
+		return
+	}
+	fmt.Fprintf(sb, "%s.tq isolation=%v traceability=%v tested=%d classes=%d\n", prefix, tq.GlobalIsolationScore, tq.TraceabilityPct, tq.NbTestedClasses, tq.NbProdClasses)
+	for i, godTest := range tq.GodTests {
+		fmt.Fprintf(sb, "%s.tq.godTest[%d]=%s fanOut=%d\n", prefix, i, godTest.FilePath, godTest.SUTFanOut)
+	}
+	for i, orphan := range tq.OrphanClasses {
+		fmt.Fprintf(sb, "%s.tq.orphan[%d]=%s weight=%v file=%s\n", prefix, i, orphan.ClassName, orphan.Weight, orphan.FilePath)
+	}
+}
+
+func snapshotCommunity(sb *strings.Builder, prefix string, community *analyzer.CommunityMetrics) {
+	if community == nil {
+		return
+	}
+	fmt.Fprintf(sb, "%s.community count=%d avgSize=%v maxSize=%d density=%v modularity=%v\n",
+		prefix, community.CommunitiesCount, community.AvgSize, community.MaxSize, community.GraphDensity, community.ModularityQ)
+	fmt.Fprintf(sb, "%s.community.matrixOrder=%s\n", prefix, strings.Join(community.MatrixOrder, ","))
+	fmt.Fprintf(sb, "%s.community.boundaryNodes=%s\n", prefix, strings.Join(community.BoundaryNodes, ","))
+	for _, id := range sortedKeysOf(community.Communities) {
+		fmt.Fprintf(sb, "%s.community[%s]=%s purity=%v inbound=%d outbound=%d\n",
+			prefix, id, strings.Join(community.Communities[id], ","),
+			community.PurityPerCommunity[id], community.InboundEdgesPerComm[id], community.OutboundEdgesPerComm[id])
+	}
+	for i, edge := range community.EdgesBetweenCommunities {
+		fmt.Fprintf(sb, "%s.community.edge[%d]=%v\n", prefix, i, edge)
+	}
+}
+
+func sortedKeysOf[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// firstDifference points at the first differing line, so a failure reads as one
+// line instead of a whole report.
+func firstDifference(expected, actual string) string {
+	expectedLines := strings.Split(expected, "\n")
+	actualLines := strings.Split(actual, "\n")
+	for i := range max(len(expectedLines), len(actualLines)) {
+		var left, right string
+		if i < len(expectedLines) {
+			left = expectedLines[i]
+		}
+		if i < len(actualLines) {
+			right = actualLines[i]
+		}
+		if left != right {
+			return fmt.Sprintf("line %d\n  first run: %s\n  this run:  %s", i+1, left, right)
+		}
+	}
+	return "the two outputs are identical, which contradicts the comparison above"
+}

--- a/internal/engine/ast_dumper.go
+++ b/internal/engine/ast_dumper.go
@@ -17,6 +17,11 @@ type DumpOptions struct {
 	ProgressText func(done, total int, path string) string
 }
 
+type dumpJob struct {
+	index int
+	path  string
+}
+
 func DumpFiles(
 	files []string,
 	progress *pterm.SpinnerPrinter,
@@ -31,12 +36,14 @@ func DumpFiles(
 	}
 
 	var wg sync.WaitGroup
-	jobs := make(chan string, opts.Concurrency)
+	jobs := make(chan dumpJob, opts.Concurrency)
 	total := len(files)
 	done := 0
 	var mu sync.Mutex
 
-	results := make([]*pb.File, 0, total)
+	// Workers finish in an arbitrary order. Keep one result slot per input file
+	// so downstream aggregation always receives files in discovery order.
+	results := make([]*pb.File, total)
 
 	if opts.ProgressText == nil {
 		opts.ProgressText = func(done, total int, _ string) string {
@@ -48,25 +55,23 @@ func DumpFiles(
 	}
 
 	worker := func() {
-		for path := range jobs {
+		for job := range jobs {
 			if opts.ProgressText != nil && progress != nil {
 				mu.Lock()
 				done++
-				progress.UpdateText(opts.ProgressText(done, total, path))
+				progress.UpdateText(opts.ProgressText(done, total, job.path))
 				mu.Unlock()
 			}
 
 			if opts.BeforeParse != nil {
-				opts.BeforeParse(path)
+				opts.BeforeParse(job.path)
 			}
 
-			if file, err := parse(path); err == nil && file != nil {
+			if file, err := parse(job.path); err == nil && file != nil {
 				if opts.AfterParse != nil {
 					opts.AfterParse(file)
 				}
-				mu.Lock()
-				results = append(results, file)
-				mu.Unlock()
+				results[job.index] = file
 			}
 			wg.Done()
 		}
@@ -75,14 +80,23 @@ func DumpFiles(
 	for i := 0; i < opts.Concurrency; i++ {
 		go worker()
 	}
-	for _, f := range files {
+	for i, f := range files {
 		wg.Add(1)
-		jobs <- f
+		jobs <- dumpJob{index: i, path: f}
 	}
 	close(jobs)
 	wg.Wait()
 	if progress != nil {
 		progress.Info("AST parsed")
 	}
-	return results
+
+	// Parsing errors leave nil slots. Compact them without disturbing the
+	// relative order of successfully parsed files.
+	parsed := results[:0]
+	for _, file := range results {
+		if file != nil {
+			parsed = append(parsed, file)
+		}
+	}
+	return parsed
 }

--- a/internal/mcp/tools_testquality.go
+++ b/internal/mcp/tools_testquality.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -44,8 +45,10 @@ func handleGetTestQuality(svc *AnalysisService) func(ctx context.Context, reques
 			IsolationScore float64 `json:"isolation_score"`
 			IsolationLabel string  `json:"isolation_label"`
 		}
+		// Only the head of the lists: the caller is a language model, and a large
+		// project has hundreds of these.
 		var godTests []godTest
-		for _, gt := range tq.GodTests {
+		for _, gt := range analyzer.Top(tq.GodTests) {
 			godTests = append(godTests, godTest{
 				FilePath:       gt.FilePath,
 				FanOut:         gt.SUTFanOut,
@@ -62,7 +65,7 @@ func handleGetTestQuality(svc *AnalysisService) func(ctx context.Context, reques
 			Weight     float64 `json:"weight"`
 		}
 		var orphans []orphan
-		for _, oc := range tq.OrphanClasses {
+		for _, oc := range analyzer.Top(tq.OrphanClasses) {
 			orphans = append(orphans, orphan{
 				ClassName:  oc.ClassName,
 				FilePath:   oc.FilePath,
@@ -73,14 +76,14 @@ func handleGetTestQuality(svc *AnalysisService) func(ctx context.Context, reques
 
 		result := map[string]any{
 			"global_isolation_score": tq.GlobalIsolationScore,
-			"isolation_label":       tq.IsolationLabel,
-			"traceability_pct":      tq.TraceabilityPct,
-			"nb_test_files":         tq.NbTestFiles,
-			"nb_prod_files":         tq.NbProdFiles,
-			"nb_prod_classes":       tq.NbProdClasses,
-			"nb_tested_classes":     tq.NbTestedClasses,
-			"god_tests":             godTests,
-			"orphan_classes":        orphans,
+			"isolation_label":        tq.IsolationLabel,
+			"traceability_pct":       tq.TraceabilityPct,
+			"nb_test_files":          tq.NbTestFiles,
+			"nb_prod_files":          tq.NbProdFiles,
+			"nb_prod_classes":        tq.NbProdClasses,
+			"nb_tested_classes":      tq.NbTestedClasses,
+			"god_tests":              godTests,
+			"orphan_classes":         orphans,
 			"isolation_histogram": map[string]int{
 				"0-19":   tq.IsolationHistogram[0],
 				"20-39":  tq.IsolationHistogram[1],


### PR DESCRIPTION
Thanks for the report. The unstable baseline was hiding a bigger problem: the analysis itself was not determinist, due to random order of analysis workers :

- Results were folded back in whatever order the worker goroutines happened to finish. Float addition is not associative, so the project totals shifted in their last digits on every run.
- Lists sorted on a metric had no tie-break, so equally-weighted entries swapped places in the top-20 the lint rules read. That is the diff you were seeing.
- The baseline stored absolute paths, so one generated in your container would have matched nothing on a host or in CI.

I hope all fixed now