### PR TITLE
[BC] feat(cli): add optional architecture analysis flag

### DIFF
--- a/cmd/ast-metrics/main.go
+++ b/cmd/ast-metrics/main.go
@@ -349,6 +349,11 @@ func main() {
 						Usage:    "Generate a profiling reports into files ast-metrics.cpu and ast-metrics.mem",
 						Category: "Global options",
 					},
+					&cliV2.BoolFlag{
+						Name:     "architecture",
+						Usage:    "Enable AI-based architecture classification",
+						Category: "Analysis",
+					},
 					// Extra file extensions per language
 					&cliV2.StringFlag{
 						Name:     "php-extensions",
@@ -485,6 +490,9 @@ func main() {
 
 					// Merge extra file extensions from CLI flags into config
 					mergeExtensionFlags(cCtx, config)
+
+					// The AI classifier is opt-in to keep the default analysis fast.
+					config.Architecture = cCtx.Bool("architecture")
 
 					// Reports
 					if cCtx.String("report-html") != "" {
@@ -802,6 +810,7 @@ func main() {
 				Usage: "Run lint then full analysis with reports (CI mode)",
 				Flags: []cliV2.Flag{
 					&cliV2.BoolFlag{Name: "verbose", Aliases: []string{"v"}, Usage: "Enable verbose mode", Category: "Global options"},
+					&cliV2.BoolFlag{Name: "architecture", Usage: "Enable AI-based architecture classification", Category: "Analysis"},
 					&cliV2.StringSliceFlag{Name: "exclude", Usage: "Regular expression to exclude files from analysis", Category: "File selection"},
 					&cliV2.StringFlag{Name: "report-html", Usage: "Generate an HTML report", Category: "Report"},
 					&cliV2.BoolFlag{Name: "open-html", Usage: "Automatically open HTML report in browser", Category: "Report"},
@@ -865,6 +874,9 @@ func main() {
 					}
 					// Merge extra file extensions from CLI flags into config
 					mergeExtensionFlags(cCtx, cfg)
+
+					// The AI classifier is opt-in to keep the default analysis fast.
+					cfg.Architecture = cCtx.Bool("architecture")
 					// Reports from flags
 					if cCtx.String("report-html") != "" {
 						cfg.Reports.Html = cCtx.String("report-html")

--- a/internal/command/analyze_command.go
+++ b/internal/command/analyze_command.go
@@ -23,25 +23,47 @@ import (
 )
 
 type AnalyzeCommand struct {
-	Configuration   *configuration.Configuration
-	outWriter       *bufio.Writer
-	runners         []engine.Engine
-	isInteractive   bool
-	moonSpinner     *pterm.SpinnerPrinter
-	alreadyExecuted bool
-	currentPage     *cli.ScreenHome
-	FileWatcher     *fsnotify.Watcher
-	gitSummaries    []analyzer.ResultOfGitAnalysis
+	Configuration       *configuration.Configuration
+	outWriter           *bufio.Writer
+	runners             []engine.Engine
+	predictArchitecture func(string, []*pb.File, string) ([]classifier.ClassPrediction, error)
+	isInteractive       bool
+	moonSpinner         *pterm.SpinnerPrinter
+	alreadyExecuted     bool
+	currentPage         *cli.ScreenHome
+	FileWatcher         *fsnotify.Watcher
+	gitSummaries        []analyzer.ResultOfGitAnalysis
 }
 
 func NewAnalyzeCommand(configuration *configuration.Configuration, outWriter *bufio.Writer, runners []engine.Engine, isInteractive bool) *AnalyzeCommand {
 	return &AnalyzeCommand{
-		Configuration:   configuration,
-		outWriter:       outWriter,
-		runners:         runners,
+		Configuration: configuration,
+		outWriter:     outWriter,
+		runners:       runners,
+		predictArchitecture: func(modelDirectory string, files []*pb.File, root string) ([]classifier.ClassPrediction, error) {
+			return classifier.NewPredictor(modelDirectory).Predict(files, root)
+		},
 		isInteractive:   isInteractive,
 		alreadyExecuted: false,
 	}
+}
+
+func (v *AnalyzeCommand) runArchitectureClassification(allResults []*pb.File, projectAggregated *analyzer.ProjectAggregated) {
+	if v.Configuration == nil || !v.Configuration.Architecture || len(v.Configuration.SourcesToAnalyzePath) == 0 {
+		return
+	}
+
+	predictions, err := v.predictArchitecture(
+		v.Configuration.ModelClassifierDirectory,
+		allResults,
+		v.Configuration.SourcesToAnalyzePath[0],
+	)
+	if err != nil {
+		log.Debugf("Classification skipped: %v", err)
+		return
+	}
+
+	projectAggregated.Predictions = predictions
 }
 
 func (v *AnalyzeCommand) Execute() error {
@@ -155,16 +177,9 @@ func (v *AnalyzeCommand) Execute() error {
 		projectAggregated.Evaluation = &evaluation
 	}
 
-	// AI-based architecture classification
-	if len(v.Configuration.SourcesToAnalyzePath) > 0 {
-		predictor := classifier.NewPredictor(v.Configuration.ModelClassifierDirectory)
-		predictions, err := predictor.Predict(allResults, v.Configuration.SourcesToAnalyzePath[0])
-		if err != nil {
-			log.Debugf("Classification skipped: %v", err)
-		} else {
-			projectAggregated.Predictions = predictions
-		}
-	}
+	// AI-based architecture classification is opt-in because loading and running
+	// the local models is significantly more expensive than the static analysis.
+	v.runArchitectureClassification(allResults, &projectAggregated)
 
 	// Generate reports
 	if v.moonSpinner != nil {

--- a/internal/command/analyze_command_test.go
+++ b/internal/command/analyze_command_test.go
@@ -5,9 +5,43 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ast-metrics/ast-metrics/internal/analyzer"
+	"github.com/ast-metrics/ast-metrics/internal/analyzer/classifier"
 	"github.com/ast-metrics/ast-metrics/internal/configuration"
 	"github.com/ast-metrics/ast-metrics/internal/storage"
+	pb "github.com/ast-metrics/ast-metrics/pb"
 )
+
+func TestAnalyzeCommand_ArchitectureClassificationIsOptIn(t *testing.T) {
+	config := configuration.NewConfiguration()
+	config.SourcesToAnalyzePath = []string{"/project"}
+	cmd := NewAnalyzeCommand(config, bufio.NewWriter(os.Stdout), nil, false)
+
+	calls := 0
+	expected := []classifier.ClassPrediction{{Class: "App\\Controller"}}
+	cmd.predictArchitecture = func(string, []*pb.File, string) ([]classifier.ClassPrediction, error) {
+		calls++
+		return expected, nil
+	}
+
+	aggregated := analyzer.ProjectAggregated{}
+	cmd.runArchitectureClassification(nil, &aggregated)
+	if calls != 0 {
+		t.Fatalf("architecture classifier called %d time(s) without --architecture; want 0", calls)
+	}
+	if aggregated.Predictions != nil {
+		t.Fatalf("predictions populated without --architecture: %#v", aggregated.Predictions)
+	}
+
+	config.Architecture = true
+	cmd.runArchitectureClassification(nil, &aggregated)
+	if calls != 1 {
+		t.Fatalf("architecture classifier called %d time(s) with --architecture; want 1", calls)
+	}
+	if len(aggregated.Predictions) != 1 || aggregated.Predictions[0].Class != expected[0].Class {
+		t.Fatalf("predictions = %#v; want %#v", aggregated.Predictions, expected)
+	}
+}
 
 func TestAnalyzeCommand_Execute(t *testing.T) {
 	t.Run("TestAnalyzeCommand_Execute", func(t *testing.T) {

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -30,6 +30,10 @@ type Configuration struct {
 	// if not empty, compare the current analysis with the one in this branch / commit
 	CompareWith string `yaml:"comparewith,omitempty"`
 
+	// Architecture enables the optional AI-based architecture classification.
+	// It is intentionally CLI-only because loading the classifier is expensive.
+	Architecture bool `yaml:"-"`
+
 	// Extra file extensions per language (e.g. {"php": [".inc", ".module"]})
 	Extensions map[string][]string `yaml:"extensions,omitempty"`
 
@@ -167,6 +171,7 @@ func NewConfiguration() *Configuration {
 		ExcludePatterns:          []string{"/vendor/", "/node_modules/", "/.git/", "/.idea/", "/_ide_helper/", "/var/", "/.claude/", "/.venv/", "/__pycache__/"},
 		Watching:                 false,
 		CompareWith:              "",
+		Architecture:             false,
 		Storage:                  storage.Default(),
 		IsComingFromConfigFile:   false,
 		ModelClassifierDirectory: "ai/training/classifier/build",


### PR DESCRIPTION
Today, when we run an analysis, we run:

- metrics extraction
- Louvain extraction
- neural analysis (currently only supported for PHP)

In my day-to-day development workflow, I don't want to wait for the neural analysis every time I run AST Metrics.