### PR TITLE
feat(cli): add optional architecture analysis flag

### DIFF
--- a/internal/analyzer/namer/namer.go
+++ b/internal/analyzer/namer/namer.go
@@ -11,11 +11,11 @@ var fs embed.FS
 
 // embedded parses the bundled dictionary once per process.
 //
-// Ten megabytes of vectors are decoded into a map of a hundred thousand
-// entries, and a run builds a Namer for every aggregation scope: the global
-// view, the per-file view, and one per language and per analyzed directory. Each
-// of them used to decode the same dictionary again, for a result none of them
-// modifies afterwards.
+// Ten megabytes of vectors are decoded into a map of a hundred thousand entries,
+// and a run builds a Namer for every aggregation scope: the global view, the
+// per-file view, and one per language and per analyzed directory. They all read
+// the same dictionary and none of them modifies it, so decoding it per Namer
+// would be the same work done again for the same answer.
 var embedded = sync.OnceValues(func() (map[string][]float32, int) {
 	data, err := fs.ReadFile("vectors.w2v")
 	if err != nil {

--- a/internal/analyzer/namer/namer.go
+++ b/internal/analyzer/namer/namer.go
@@ -3,10 +3,30 @@ package namer
 import (
 	"embed"
 	"errors"
+	"sync"
 )
 
 //go:embed vectors.w2v
 var fs embed.FS
+
+// embedded parses the bundled dictionary once per process.
+//
+// Ten megabytes of vectors are decoded into a map of a hundred thousand
+// entries, and a run builds a Namer for every aggregation scope: the global
+// view, the per-file view, and one per language and per analyzed directory. Each
+// of them used to decode the same dictionary again, for a result none of them
+// modifies afterwards.
+var embedded = sync.OnceValues(func() (map[string][]float32, int) {
+	data, err := fs.ReadFile("vectors.w2v")
+	if err != nil {
+		return nil, 0
+	}
+	vectors, dim, err := loadW2V(data)
+	if err != nil {
+		return nil, 0
+	}
+	return vectors, dim
+})
 
 // Namer derives a short label (1–3 words) for a cluster of class names
 // using token embeddings (word vectors).
@@ -36,14 +56,9 @@ func NewNamer(opts ...Option) (*Namer, error) {
 	}
 
 	if n.vectors == nil {
-		data, err := fs.ReadFile("vectors.w2v")
-		if err != nil {
-			return nil, err
-		}
-
-		vectors, dim, err := loadW2V(data)
-		if err != nil {
-			return nil, err
+		vectors, dim := embedded()
+		if len(vectors) == 0 {
+			return nil, errors.New("namer: cannot read the embedded vectors")
 		}
 
 		n.vectors = vectors

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -8,20 +8,18 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/charmbracelet/lipgloss"
 	pb "github.com/ast-metrics/ast-metrics/pb"
+	"github.com/charmbracelet/lipgloss"
 	osterm "golang.org/x/term"
 )
 
+// Colours are fixed, never lipgloss.AdaptiveColor: resolving an adaptive colour
+// makes lipgloss ask the terminal for its background colour (OSC 11), and a
+// terminal that does not answer costs termenv.OSCTimeout, five seconds, before
+// the analysis has even started. The palette below assumes a dark background,
+// like the rest of the interface.
 var (
-	subtle  = lipgloss.AdaptiveColor{Light: "#D9DCCF", Dark: "#383838"}
-	special = lipgloss.AdaptiveColor{Light: "#43BF6D", Dark: "#73F59F"}
-
-	divider = lipgloss.NewStyle().
-		SetString("•").
-		Padding(0, 1).
-		Foreground(subtle).
-		String()
+	special = lipgloss.Color("#73F59F")
 
 	titleStyle = lipgloss.NewStyle().
 			Padding(1).

--- a/internal/engine/comments.go
+++ b/internal/engine/comments.go
@@ -316,46 +316,73 @@ func skipString(line string, i int) int {
 	return len(line)
 }
 
-// CountLinesOfCode measures the 1-based inclusive line range [start, end] of a
-// file whose lines are given whole, so that a comment block opened before start
-// is still known to be open.
+// LineIndex holds what every physical line of one file holds, as running totals.
 //
-// LogicalLinesOfCode is left at zero: only a parser can fill it, following the
-// model in internal/engine/treesitter/statement.go.
-func CountLinesOfCode(sourceCode []string, start int, end int, syn CommentSyntax) *pb.LinesOfCode {
-	if start < 1 {
-		start = 1
-	}
-	if end > len(sourceCode) {
-		end = len(sourceCode)
-	}
-	if end < start {
-		end = start - 1
+// A file is scanned once, from the top: a comment block opened on line 10 makes
+// line 20 documentation, which cannot be decided from line 20 alone. Counting a
+// range is then a subtraction. A parser asks for one range per scope, and a
+// class of twenty methods asks twenty-two times, so scanning the file again for
+// each of them made the cost of a file grow with the number of scopes it holds.
+type LineIndex struct {
+	// cloc[i] and ncloc[i] hold the totals over the first i lines, so the count
+	// over [start, end] is the difference at both ends.
+	cloc  []int32
+	ncloc []int32
+	lines int
+}
+
+// NewLineIndex scans a file once and returns the index of its lines.
+func NewLineIndex(sourceCode []string, syn CommentSyntax) *LineIndex {
+	idx := &LineIndex{
+		cloc:  make([]int32, len(sourceCode)+1),
+		ncloc: make([]int32, len(sourceCode)+1),
+		lines: len(sourceCode),
 	}
 
 	s := &scanner{syn: syn}
-	var cloc, ncloc int32
-	for i := 0; i < end && i < len(sourceCode); i++ {
-		kind := s.classify(sourceCode[i])
-		if i < start-1 {
-			// scanned only to know whether a block comment is open
-			continue
-		}
-		switch kind {
+	for i, line := range sourceCode {
+		cloc, ncloc := idx.cloc[i], idx.ncloc[i]
+		switch s.classify(line) {
 		case lineComment:
 			cloc++
 		case lineCode:
 			ncloc++
 		}
+		idx.cloc[i+1], idx.ncloc[i+1] = cloc, ncloc
 	}
 
-	loc := int32(0)
-	if end >= start {
-		loc = int32(end - start + 1)
+	return idx
+}
+
+// Count measures the 1-based inclusive line range [start, end].
+//
+// LogicalLinesOfCode is left at zero: only a parser can fill it, following the
+// model in internal/engine/treesitter/statement.go.
+func (idx *LineIndex) Count(start int, end int) *pb.LinesOfCode {
+	if start < 1 {
+		start = 1
 	}
+	if end > idx.lines {
+		end = idx.lines
+	}
+	if end < start {
+		// nothing to measure: an empty range is not one line long
+		return &pb.LinesOfCode{}
+	}
+
 	return &pb.LinesOfCode{
-		LinesOfCode:           loc,
-		CommentLinesOfCode:    cloc,
-		NonCommentLinesOfCode: ncloc,
+		LinesOfCode:           int32(end - start + 1),
+		CommentLinesOfCode:    idx.cloc[end] - idx.cloc[start-1],
+		NonCommentLinesOfCode: idx.ncloc[end] - idx.ncloc[start-1],
 	}
+}
+
+// CountLinesOfCode measures the 1-based inclusive line range [start, end] of a
+// file whose lines are given whole, so that a comment block opened before start
+// is still known to be open.
+//
+// Callers that measure several ranges of the same file should build a LineIndex
+// instead, and pay the scan once.
+func CountLinesOfCode(sourceCode []string, start int, end int, syn CommentSyntax) *pb.LinesOfCode {
+	return NewLineIndex(sourceCode, syn).Count(start, end)
 }

--- a/internal/engine/comments.go
+++ b/internal/engine/comments.go
@@ -321,8 +321,8 @@ func skipString(line string, i int) int {
 // A file is scanned once, from the top: a comment block opened on line 10 makes
 // line 20 documentation, which cannot be decided from line 20 alone. Counting a
 // range is then a subtraction. A parser asks for one range per scope, and a
-// class of twenty methods asks twenty-two times, so scanning the file again for
-// each of them made the cost of a file grow with the number of scopes it holds.
+// class of twenty methods asks twenty-two times, so scanning the file for each
+// of them would make the cost of a file grow with the number of scopes it holds.
 type LineIndex struct {
 	// cloc[i] and ncloc[i] hold the totals over the first i lines, so the count
 	// over [start, end] is the difference at both ends.

--- a/internal/engine/csharp/tree_sitter_csharp_adapter.go
+++ b/internal/engine/csharp/tree_sitter_csharp_adapter.go
@@ -42,37 +42,30 @@ func (a *TreeSitterAdapter) ensureRoot(src []byte) (*sitter.Node, []byte) {
 	return a.root, source
 }
 
-func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool {
-	// namespace_declaration bodies are reached through the fallback recursion;
-	// the namespace name itself comes from ModuleNameFromPath
-	return n.Type() == "compilation_unit"
-}
+// These four questions are asked on every node of every walk, so they are
+// answered by symbol id rather than by node type name. See
+// internal/engine/treesitter/symbols.go.
+//
+// namespace_declaration bodies are reached through the fallback recursion; the
+// namespace name itself comes from ModuleNameFromPath. Structs, records
+// (including record struct) and enums are class-like containers in C#: they hold
+// fields and methods, so they count as classes for metrics. Property accessors
+// (get/set/init) and lambdas are intentionally not named functions; their bodies
+// still contribute decisions through the fallback recursion.
+var (
+	csModules    = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"compilation_unit"}}
+	csClasses    = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"class_declaration", "struct_declaration", "record_declaration", "enum_declaration"}}
+	csInterfaces = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"interface_declaration"}}
+	csFunctions  = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"method_declaration", "constructor_declaration", "local_function_statement", "destructor_declaration"}}
+)
 
-func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool {
-	switch n.Type() {
-	// structs, records (incl. record struct) and enums are class-like
-	// containers in C#: they hold fields and methods, so treat them as
-	// classes for metrics.
-	case "class_declaration", "struct_declaration", "record_declaration", "enum_declaration":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return csModules.Has(n) }
 
-func (a *TreeSitterAdapter) IsInterface(n *sitter.Node) bool {
-	return n.Type() == "interface_declaration"
-}
+func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool { return csClasses.Has(n) }
 
-func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool {
-	// Property accessors (get/set/init) and lambdas are intentionally not
-	// treated as named functions; their bodies still contribute decisions via
-	// the fallback recursion.
-	switch n.Type() {
-	case "method_declaration", "constructor_declaration", "local_function_statement", "destructor_declaration":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsInterface(n *sitter.Node) bool { return csInterfaces.Has(n) }
+
+func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool { return csFunctions.Has(n) }
 
 func (a *TreeSitterAdapter) NodeName(n *sitter.Node) string {
 	if a.src == nil || n == nil {
@@ -215,15 +208,16 @@ func (a *TreeSitterAdapter) EachChildBody(body *sitter.Node, yield func(*sitter.
 // section, which lets a section carrying several labels count each of them.
 // `??` is deliberately not a logical operator here, as in PHP and TypeScript.
 var csDecisions = &Treesitter.DecisionSpec{
-	If:      []string{"if_statement"},
-	Loop:    []string{"for_statement", "foreach_statement", "while_statement", "do_statement"},
-	Switch:  []string{"switch_statement", "switch_expression"},
-	Case:    []string{"case", "switch_expression_arm"},
-	Default: []string{"default"},
-	Catch:   []string{"catch_clause"},
-	Ternary: []string{"conditional_expression"},
-	Logical: []string{"binary_expression"},
-	Ops:     []string{"&&", "||"},
+	Language: tsCSharp.GetLanguage,
+	If:       []string{"if_statement"},
+	Loop:     []string{"for_statement", "foreach_statement", "while_statement", "do_statement"},
+	Switch:   []string{"switch_statement", "switch_expression"},
+	Case:     []string{"case", "switch_expression_arm"},
+	Default:  []string{"default"},
+	Catch:    []string{"catch_clause"},
+	Ternary:  []string{"conditional_expression"},
+	Logical:  []string{"binary_expression"},
+	Ops:      []string{"&&", "||"},
 }
 
 func (a *TreeSitterAdapter) Decision(n *sitter.Node) Treesitter.DecisionKind {
@@ -300,6 +294,7 @@ func (a *TreeSitterAdapter) Imports(n *sitter.Node) []Treesitter.ImportItem {
 // while a `using` block inside a method does, which is why only
 // `using_statement` is listed.
 var csharpStatements = &Treesitter.StatementSpec{
+	Language: tsCSharp.GetLanguage,
 	Statement: []string{
 		"expression_statement", "local_declaration_statement",
 		"if_statement",

--- a/internal/engine/csharp/tree_sitter_csharp_adapter.go
+++ b/internal/engine/csharp/tree_sitter_csharp_adapter.go
@@ -48,18 +48,22 @@ func (a *TreeSitterAdapter) ensureRoot(src []byte) (*sitter.Node, []byte) {
 // These four questions are asked on every node of every walk, so they are
 // answered by symbol id rather than by node type name. See
 // internal/engine/treesitter/symbols.go.
-//
-// namespace_declaration bodies are reached through the fallback recursion; the
-// namespace name itself comes from ModuleNameFromPath. Structs, records
-// (including record struct) and enums are class-like containers in C#: they hold
-// fields and methods, so they count as classes for metrics. Property accessors
-// (get/set/init) and lambdas are intentionally not named functions; their bodies
-// still contribute decisions through the fallback recursion.
 var (
-	csModules    = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"compilation_unit"}}
-	csClasses    = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"class_declaration", "struct_declaration", "record_declaration", "enum_declaration"}}
+	// namespace_declaration bodies are reached through the fallback recursion;
+	// the namespace name itself comes from ModuleNameFromPath
+	csModules = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"compilation_unit"}}
+
+	// structs, records (including record struct) and enums are class-like
+	// containers in C#: they hold fields and methods, so they count as classes
+	// for metrics
+	csClasses = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"class_declaration", "struct_declaration", "record_declaration", "enum_declaration"}}
+
 	csInterfaces = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"interface_declaration"}}
-	csFunctions  = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"method_declaration", "constructor_declaration", "local_function_statement", "destructor_declaration"}}
+
+	// property accessors (get/set/init) and lambdas are intentionally not named
+	// functions; their bodies still contribute decisions through the fallback
+	// recursion
+	csFunctions = &Treesitter.TypeSet{Language: tsCSharp.GetLanguage, Types: []string{"method_declaration", "constructor_declaration", "local_function_statement", "destructor_declaration"}}
 )
 
 func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return csModules.Has(n) }

--- a/internal/engine/csharp/tree_sitter_csharp_adapter.go
+++ b/internal/engine/csharp/tree_sitter_csharp_adapter.go
@@ -16,6 +16,9 @@ type TreeSitterAdapter struct {
 	// ns caches the declared namespace (parsed lazily from src)
 	ns       string
 	nsParsed bool
+	// srcLines holds the source split into lines, so that the extractors called
+	// once per function do not split the whole file again for each of them
+	srcLines Treesitter.LineCache
 }
 
 func NewTreeSitterAdapter(src []byte) *TreeSitterAdapter   { return &TreeSitterAdapter{src: src} }
@@ -405,7 +408,7 @@ func (a *TreeSitterAdapter) ExtractMethodCalls(src []byte, startLine, endLine in
 	if src == nil || startLine <= 0 || endLine <= 0 || endLine < startLine {
 		return nil
 	}
-	lines := strings.Split(string(src), "\n")
+	lines := a.srcLines.Lines(src)
 	var calls []string
 	for i := startLine - 1; i < endLine && i < len(lines); i++ {
 		ln := strings.TrimSpace(lines[i])

--- a/internal/engine/golang/tree_sitter_go_adapter.go
+++ b/internal/engine/golang/tree_sitter_go_adapter.go
@@ -39,13 +39,20 @@ func (a *TreeSitterAdapter) ensureRoot(src []byte) (*sitter.Node, []byte) {
 	return a.root, source
 }
 
-func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return n.Type() == "source_file" }
+// These questions are asked on every node of every walk, so they are answered
+// by symbol id rather than by node type name. See
+// internal/engine/treesitter/symbols.go.
+var (
+	goModules      = &Treesitter.TypeSet{Language: tsGo.GetLanguage, Types: []string{"source_file"}}
+	goTypeDecls    = &Treesitter.TypeSet{Language: tsGo.GetLanguage, Types: []string{"type_declaration"}}
+	goFunctionsSet = &Treesitter.TypeSet{Language: tsGo.GetLanguage, Types: []string{"function_declaration", "method_declaration"}}
+)
+
+func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return goModules.Has(n) }
 func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool {
-	return n.Type() == "type_declaration" && firstChildOfType(n, "type_spec") != nil && firstDescendantOfType(n, "type_identifier") != nil && firstDescendantOfType(n, "type_parameter_list") == nil && firstDescendantOfType(n, "struct_type") != nil
+	return goTypeDecls.Has(n) && firstChildOfType(n, "type_spec") != nil && firstDescendantOfType(n, "type_identifier") != nil && firstDescendantOfType(n, "type_parameter_list") == nil && firstDescendantOfType(n, "struct_type") != nil
 }
-func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool {
-	return n.Type() == "function_declaration" || n.Type() == "method_declaration"
-}
+func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool { return goFunctionsSet.Has(n) }
 
 func (a *TreeSitterAdapter) NodeName(n *sitter.Node) string {
 	switch n.Type() {
@@ -177,13 +184,14 @@ func (a *TreeSitterAdapter) EachChildBody(body *sitter.Node, yield func(*sitter.
 // and `for_clause` are children of `for_statement`, which is the single loop
 // node of the grammar, so only the latter is listed.
 var goDecisions = &Treesitter.DecisionSpec{
-	If:      []string{"if_statement"},
-	Loop:    []string{"for_statement"},
-	Switch:  []string{"expression_switch_statement", "type_switch_statement", "select_statement"},
-	Case:    []string{"expression_case", "type_case", "communication_case"},
-	Default: []string{"default_case"},
-	Logical: []string{"binary_expression"},
-	Ops:     []string{"&&", "||"},
+	Language: tsGo.GetLanguage,
+	If:       []string{"if_statement"},
+	Loop:     []string{"for_statement"},
+	Switch:   []string{"expression_switch_statement", "type_switch_statement", "select_statement"},
+	Case:     []string{"expression_case", "type_case", "communication_case"},
+	Default:  []string{"default_case"},
+	Logical:  []string{"binary_expression"},
+	Ops:      []string{"&&", "||"},
 }
 
 func (a *TreeSitterAdapter) Decision(n *sitter.Node) Treesitter.DecisionKind {
@@ -420,6 +428,7 @@ func goMethodAtLine(n *sitter.Node, line int) *sitter.Node {
 // The case clauses of a switch and of a select are labels, not instructions:
 // what they hold counts on its own lines.
 var goStatements = &Treesitter.StatementSpec{
+	Language: tsGo.GetLanguage,
 	Statement: []string{
 		"assignment_statement", "expression_statement", "inc_statement", "dec_statement",
 		"short_var_declaration", "send_statement",

--- a/internal/engine/java/tree_sitter_java_adapter.go
+++ b/internal/engine/java/tree_sitter_java_adapter.go
@@ -48,17 +48,19 @@ func (a *TreeSitterAdapter) ensureRoot(src []byte) (*sitter.Node, []byte) {
 // These four questions are asked on every node of every walk, so they are
 // answered by symbol id rather than by node type name. See
 // internal/engine/treesitter/symbols.go.
-//
-// Enums, records and annotation types are class-like containers in Java: they
-// hold fields and methods, so they count as classes for metrics. Lambdas are
-// intentionally not named functions: they have no name and would pollute method
-// counts, and their bodies still contribute decisions to the enclosing method
-// through the fallback recursion.
 var (
-	javaModules    = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"program"}}
-	javaClasses    = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"class_declaration", "enum_declaration", "record_declaration", "annotation_type_declaration"}}
+	javaModules = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"program"}}
+
+	// enums, records and annotation types are class-like containers in Java:
+	// they hold fields and methods, so they count as classes for metrics
+	javaClasses = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"class_declaration", "enum_declaration", "record_declaration", "annotation_type_declaration"}}
+
 	javaInterfaces = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"interface_declaration"}}
-	javaFunctions  = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"method_declaration", "constructor_declaration"}}
+
+	// lambdas are intentionally not named functions: they have no name and would
+	// pollute method counts, and their bodies still contribute decisions to the
+	// enclosing method through the fallback recursion
+	javaFunctions = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"method_declaration", "constructor_declaration"}}
 )
 
 func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return javaModules.Has(n) }

--- a/internal/engine/java/tree_sitter_java_adapter.go
+++ b/internal/engine/java/tree_sitter_java_adapter.go
@@ -42,32 +42,29 @@ func (a *TreeSitterAdapter) ensureRoot(src []byte) (*sitter.Node, []byte) {
 	return a.root, source
 }
 
-func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return n.Type() == "program" }
+// These four questions are asked on every node of every walk, so they are
+// answered by symbol id rather than by node type name. See
+// internal/engine/treesitter/symbols.go.
+//
+// Enums, records and annotation types are class-like containers in Java: they
+// hold fields and methods, so they count as classes for metrics. Lambdas are
+// intentionally not named functions: they have no name and would pollute method
+// counts, and their bodies still contribute decisions to the enclosing method
+// through the fallback recursion.
+var (
+	javaModules    = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"program"}}
+	javaClasses    = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"class_declaration", "enum_declaration", "record_declaration", "annotation_type_declaration"}}
+	javaInterfaces = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"interface_declaration"}}
+	javaFunctions  = &Treesitter.TypeSet{Language: tsJava.GetLanguage, Types: []string{"method_declaration", "constructor_declaration"}}
+)
 
-func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool {
-	switch n.Type() {
-	// enums, records and annotation types are class-like containers in Java:
-	// they hold fields and methods, so treat them as classes for metrics.
-	case "class_declaration", "enum_declaration", "record_declaration", "annotation_type_declaration":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return javaModules.Has(n) }
 
-func (a *TreeSitterAdapter) IsInterface(n *sitter.Node) bool {
-	return n.Type() == "interface_declaration"
-}
+func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool { return javaClasses.Has(n) }
 
-func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool {
-	// Lambdas are intentionally not treated as named functions: they have no
-	// name and would pollute method counts. Their bodies still contribute
-	// decisions to the enclosing method via the fallback recursion.
-	switch n.Type() {
-	case "method_declaration", "constructor_declaration":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsInterface(n *sitter.Node) bool { return javaInterfaces.Has(n) }
+
+func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool { return javaFunctions.Has(n) }
 
 func (a *TreeSitterAdapter) NodeName(n *sitter.Node) string {
 	if a.src == nil || n == nil {
@@ -202,14 +199,15 @@ func (a *TreeSitterAdapter) EachChildBody(body *sitter.Node, yield func(*sitter.
 // two labels sharing one body (`case 1: case 2:`) count as the two entry
 // points they are. switch_expression covers statements and expressions alike.
 var javaDecisions = &Treesitter.DecisionSpec{
-	If:      []string{"if_statement"},
-	Loop:    []string{"for_statement", "enhanced_for_statement", "while_statement", "do_statement"},
-	Switch:  []string{"switch_expression"},
-	Case:    []string{"switch_label"},
-	Catch:   []string{"catch_clause"},
-	Ternary: []string{"ternary_expression"},
-	Logical: []string{"binary_expression"},
-	Ops:     []string{"&&", "||"},
+	Language: tsJava.GetLanguage,
+	If:       []string{"if_statement"},
+	Loop:     []string{"for_statement", "enhanced_for_statement", "while_statement", "do_statement"},
+	Switch:   []string{"switch_expression"},
+	Case:     []string{"switch_label"},
+	Catch:    []string{"catch_clause"},
+	Ternary:  []string{"ternary_expression"},
+	Logical:  []string{"binary_expression"},
+	Ops:      []string{"&&", "||"},
 }
 
 func (a *TreeSitterAdapter) Decision(n *sitter.Node) Treesitter.DecisionKind {
@@ -269,6 +267,7 @@ func (a *TreeSitterAdapter) Imports(n *sitter.Node) []Treesitter.ImportItem {
 // `static_initializer`, `method_declaration` and `import_declaration` declare
 // members.
 var javaStatements = &Treesitter.StatementSpec{
+	Language: tsJava.GetLanguage,
 	Statement: []string{
 		"expression_statement", "local_variable_declaration",
 		"if_statement",

--- a/internal/engine/java/tree_sitter_java_adapter.go
+++ b/internal/engine/java/tree_sitter_java_adapter.go
@@ -16,6 +16,9 @@ type TreeSitterAdapter struct {
 	// pkg caches the declared package name (parsed lazily from src)
 	pkg       string
 	pkgParsed bool
+	// srcLines holds the source split into lines, so that the extractors called
+	// once per function do not split the whole file again for each of them
+	srcLines Treesitter.LineCache
 }
 
 func NewTreeSitterAdapter(src []byte) *TreeSitterAdapter   { return &TreeSitterAdapter{src: src} }
@@ -379,7 +382,7 @@ func (a *TreeSitterAdapter) ExtractMethodCalls(src []byte, startLine, endLine in
 	if src == nil || startLine <= 0 || endLine <= 0 || endLine < startLine {
 		return nil
 	}
-	lines := strings.Split(string(src), "\n")
+	lines := a.srcLines.Lines(src)
 	var calls []string
 	for i := startLine - 1; i < endLine && i < len(lines); i++ {
 		ln := strings.TrimSpace(lines[i])

--- a/internal/engine/php/tree_sitter_php_adapter.go
+++ b/internal/engine/php/tree_sitter_php_adapter.go
@@ -62,28 +62,25 @@ func (a *TreeSitterAdapter) ensureRoot(src []byte) (*sitter.Node, []byte) {
 }
 
 // ---- Structure detection ----
-func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return n.Type() == "program" }
+//
+// These four questions are asked on every node of every walk, so they are
+// answered by symbol id rather than by node type name. See
+// internal/engine/treesitter/symbols.go.
+var (
+	phpModules    = &Treesitter.TypeSet{Language: tsPhp.GetLanguage, Types: []string{"program"}}
+	phpClasses    = &Treesitter.TypeSet{Language: tsPhp.GetLanguage, Types: []string{"class_declaration", "trait_declaration", "enum_declaration"}}
+	phpInterfaces = &Treesitter.TypeSet{Language: tsPhp.GetLanguage, Types: []string{"interface_declaration"}}
+	phpFunctions  = &Treesitter.TypeSet{Language: tsPhp.GetLanguage, Types: []string{"function_definition", "method_declaration"}}
+)
 
-func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool {
-	switch n.Type() {
-	case "class_declaration", "trait_declaration", "enum_declaration":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return phpModules.Has(n) }
+
+func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool { return phpClasses.Has(n) }
 
 // Optional interface awareness for Visitor
-func (a *TreeSitterAdapter) IsInterface(n *sitter.Node) bool {
-	return n != nil && n.Type() == "interface_declaration"
-}
+func (a *TreeSitterAdapter) IsInterface(n *sitter.Node) bool { return phpInterfaces.Has(n) }
 
-func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool {
-	switch n.Type() {
-	case "function_definition", "method_declaration":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool { return phpFunctions.Has(n) }
 
 // ---- Attributes ----
 func (a *TreeSitterAdapter) NodeName(n *sitter.Node) string {
@@ -200,17 +197,18 @@ func (a *TreeSitterAdapter) EachChildBody(body *sitter.Node, yield func(*sitter.
 // with lizard, phploc and PMD, and with the languages that have no such
 // operator.
 var phpDecisions = &Treesitter.DecisionSpec{
-	If:      []string{"if_statement"},
-	Elif:    []string{"else_if_clause"},
-	Else:    []string{"else_clause"},
-	Loop:    []string{"while_statement", "for_statement", "foreach_statement", "do_statement"},
-	Switch:  []string{"switch_statement", "match_expression"},
-	Case:    []string{"case_statement", "match_conditional_expression"},
-	Default: []string{"default_statement", "match_default_expression"},
-	Catch:   []string{"catch_clause"},
-	Ternary: []string{"conditional_expression"},
-	Logical: []string{"binary_expression"},
-	Ops:     []string{"&&", "||", "and", "or"},
+	Language: tsPhp.GetLanguage,
+	If:       []string{"if_statement"},
+	Elif:     []string{"else_if_clause"},
+	Else:     []string{"else_clause"},
+	Loop:     []string{"while_statement", "for_statement", "foreach_statement", "do_statement"},
+	Switch:   []string{"switch_statement", "match_expression"},
+	Case:     []string{"case_statement", "match_conditional_expression"},
+	Default:  []string{"default_statement", "match_default_expression"},
+	Catch:    []string{"catch_clause"},
+	Ternary:  []string{"conditional_expression"},
+	Logical:  []string{"binary_expression"},
+	Ops:      []string{"&&", "||", "and", "or"},
 }
 
 func (a *TreeSitterAdapter) Decision(n *sitter.Node) Treesitter.DecisionKind {
@@ -853,6 +851,7 @@ func (a *TreeSitterAdapter) ExtractMethodCalls(src []byte, startLine, endLine in
 // elseif carries a condition of its own, exactly like the `if` it extends,
 // while `else_clause`, `catch_clause` and `finally_clause` are branch headers.
 var phpStatements = &Treesitter.StatementSpec{
+	Language: tsPhp.GetLanguage,
 	Statement: []string{
 		"expression_statement", "echo_statement", "unset_statement",
 		"if_statement", "else_if_clause",

--- a/internal/engine/php/tree_sitter_php_adapter.go
+++ b/internal/engine/php/tree_sitter_php_adapter.go
@@ -715,10 +715,10 @@ func foldPhpPipes(pipeLines []int, ops []string, startLine, endLine int) []strin
 // pipeLines returns the lines of the file carrying a mis-parsed "|>", found
 // once for the whole file.
 //
-// Looking for them per function meant walking down from the root for each of
-// them, so a file paid a pass over its top-level declarations once per
-// function. The operator is also rare enough that most files can be answered by
-// looking for the two characters in the source.
+// Looking for them per function would walk down from the root for each of them,
+// so a file would pay a pass over its top-level declarations once per function.
+// The operator is also rare enough that most files are answered by looking for
+// the two characters in the source.
 func (a *TreeSitterAdapter) pipeLines(root *sitter.Node, src []byte) []int {
 	if a.pipesFound {
 		return a.pipes

--- a/internal/engine/php/tree_sitter_php_adapter.go
+++ b/internal/engine/php/tree_sitter_php_adapter.go
@@ -44,6 +44,8 @@ func (a *TreeSitterAdapter) SetSource(src []byte) {
 	a.root = nil
 	a.computed = false
 	a.ns = ""
+	a.pipes = nil
+	a.pipesFound = false
 }
 func (a *TreeSitterAdapter) SetRootNode(root *sitter.Node) { a.root = root }
 

--- a/internal/engine/php/tree_sitter_php_adapter.go
+++ b/internal/engine/php/tree_sitter_php_adapter.go
@@ -1,6 +1,7 @@
 package php
 
 import (
+	"bytes"
 	"regexp"
 	"strings"
 	"unicode/utf8"
@@ -29,6 +30,12 @@ type TreeSitterAdapter struct {
 	aliases  map[string]string
 	computed bool
 	extDeps  []Treesitter.ImportItem
+	// srcLines holds the source split into lines, so that the extractors called
+	// once per function do not split the whole file again for each of them
+	srcLines Treesitter.LineCache
+	// pipes holds the lines carrying a mis-parsed "|>", found once per file
+	pipes      []int
+	pipesFound bool
 }
 
 func NewTreeSitterAdapter(src []byte) *TreeSitterAdapter { return &TreeSitterAdapter{src: src} }
@@ -666,7 +673,7 @@ func (a *TreeSitterAdapter) ExtractOperatorsOperands(src []byte, startLine, endL
 		return nil, nil
 	}
 	ops, operands := phpOperandSpec.Extract(root, source, startLine, endLine)
-	return foldPhpPipes(root, source, ops, startLine, endLine), operands
+	return foldPhpPipes(a.pipeLines(root, source), ops, startLine, endLine), operands
 }
 
 // foldPhpPipes repairs the PHP 8.5 pipe operator. The bundled grammar predates
@@ -674,8 +681,13 @@ func (a *TreeSitterAdapter) ExtractOperatorsOperands(src []byte, startLine, endL
 // and whose left side ends with an ERROR node holding a lone "|". Reporting two
 // operators where the source writes one would inflate both the vocabulary and
 // the length, so each such pair is folded back into a single "|>".
-func foldPhpPipes(root *sitter.Node, src []byte, ops []string, startLine, endLine int) []string {
-	pipes := countPhpPipes(root, src, startLine, endLine)
+func foldPhpPipes(pipeLines []int, ops []string, startLine, endLine int) []string {
+	pipes := 0
+	for _, line := range pipeLines {
+		if line >= startLine && line <= endLine {
+			pipes++
+		}
+	}
 	if pipes == 0 {
 		return ops
 	}
@@ -700,23 +712,35 @@ func foldPhpPipes(root *sitter.Node, src []byte, ops []string, startLine, endLin
 	return folded
 }
 
-// countPhpPipes counts the "|>" written between startLine and endLine.
-func countPhpPipes(root *sitter.Node, src []byte, startLine, endLine int) int {
-	count := 0
+// pipeLines returns the lines of the file carrying a mis-parsed "|>", found
+// once for the whole file.
+//
+// Looking for them per function meant walking down from the root for each of
+// them, so a file paid a pass over its top-level declarations once per
+// function. The operator is also rare enough that most files can be answered by
+// looking for the two characters in the source.
+func (a *TreeSitterAdapter) pipeLines(root *sitter.Node, src []byte) []int {
+	if a.pipesFound {
+		return a.pipes
+	}
+	a.pipesFound = true
+
+	if !bytes.Contains(src, []byte("|>")) {
+		return nil
+	}
+
 	var walk func(n *sitter.Node)
 	walk = func(n *sitter.Node) {
-		if int(n.EndPoint().Row)+1 < startLine || int(n.StartPoint().Row)+1 > endLine {
-			return
-		}
 		if n.Type() == "binary_expression" && isPhpPipe(n, src) {
-			count++
+			a.pipes = append(a.pipes, int(n.StartPoint().Row)+1)
 		}
 		for i := 0; i < int(n.ChildCount()); i++ {
 			walk(n.Child(i))
 		}
 	}
 	walk(root)
-	return count
+
+	return a.pipes
 }
 
 // isPhpPipe reports whether a binary expression is a mis-parsed "|>".
@@ -747,7 +771,7 @@ func (a *TreeSitterAdapter) ExtractMethodCalls(src []byte, startLine, endLine in
 	if src == nil || startLine <= 0 || endLine <= 0 || endLine < startLine {
 		return nil
 	}
-	lines := strings.Split(string(src), "\n")
+	lines := a.srcLines.Lines(src)
 	res := []string{}
 	add := func(s string) {
 		if s != "" {

--- a/internal/engine/python/tree_sitter_python_adapter.go
+++ b/internal/engine/python/tree_sitter_python_adapter.go
@@ -84,11 +84,18 @@ func (a *TreeSitterAdapter) EachParamIdent(params *sitter.Node, yield func(strin
 
 func (a *TreeSitterAdapter) Language() *sitter.Language { return tsPython.GetLanguage() }
 
-func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return n.Type() == "module" }
-func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool  { return n.Type() == "class_definition" }
-func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool {
-	return n.Type() == "function_definition" || n.Type() == "async_function_definition"
-}
+// These questions are asked on every node of every walk, so they are answered
+// by symbol id rather than by node type name. See
+// internal/engine/treesitter/symbols.go.
+var (
+	pythonModules   = &Treesitter.TypeSet{Language: tsPython.GetLanguage, Types: []string{"module"}}
+	pythonClasses   = &Treesitter.TypeSet{Language: tsPython.GetLanguage, Types: []string{"class_definition"}}
+	pythonFunctions = &Treesitter.TypeSet{Language: tsPython.GetLanguage, Types: []string{"function_definition", "async_function_definition"}}
+)
+
+func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool   { return pythonModules.Has(n) }
+func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool    { return pythonClasses.Has(n) }
+func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool { return pythonFunctions.Has(n) }
 
 func (a *TreeSitterAdapter) ModuleNameFromPath(path string) string {
 	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
@@ -162,16 +169,17 @@ func findDescendantOfType(n *sitter.Node, t string) *sitter.Node {
 // `if_clause` count exactly like the statements they abbreviate. `case _:` is
 // a case_clause like any other and is demoted to a Default by Decision below.
 var pythonDecisions = &Treesitter.DecisionSpec{
-	If:      []string{"if_statement", "if_clause"},
-	Elif:    []string{"elif_clause"},
-	Else:    []string{"else_clause"},
-	Loop:    []string{"for_statement", "while_statement", "for_in_clause"},
-	Switch:  []string{"match_statement"},
-	Case:    []string{"case_clause", "case_block"},
-	Catch:   []string{"except_clause", "except_group_clause"},
-	Ternary: []string{"conditional_expression"},
-	Logical: []string{"boolean_operator"},
-	Ops:     []string{"and", "or"},
+	Language: tsPython.GetLanguage,
+	If:       []string{"if_statement", "if_clause"},
+	Elif:     []string{"elif_clause"},
+	Else:     []string{"else_clause"},
+	Loop:     []string{"for_statement", "while_statement", "for_in_clause"},
+	Switch:   []string{"match_statement"},
+	Case:     []string{"case_clause", "case_block"},
+	Catch:    []string{"except_clause", "except_group_clause"},
+	Ternary:  []string{"conditional_expression"},
+	Logical:  []string{"boolean_operator"},
+	Ops:      []string{"and", "or"},
 }
 
 func (a *TreeSitterAdapter) Decision(n *sitter.Node) Treesitter.DecisionKind {
@@ -383,6 +391,7 @@ func dedup(in []Treesitter.ImportItem) []Treesitter.ImportItem {
 // any other, and is left out by the enclosing-scope rule of the shared model,
 // not by its type.
 var pythonStatements = &Treesitter.StatementSpec{
+	Language: tsPython.GetLanguage,
 	Statement: []string{
 		"expression_statement", "delete_statement", "assert_statement",
 		"if_statement", "elif_clause",

--- a/internal/engine/rust/tree_sitter_rust_adapter.go
+++ b/internal/engine/rust/tree_sitter_rust_adapter.go
@@ -116,14 +116,15 @@ func (a *TreeSitterAdapter) EachParamIdent(params *sitter.Node, yield func(strin
 // These questions are asked on every node of every walk, so they are answered
 // by symbol id rather than by node type name. See
 // internal/engine/treesitter/symbols.go.
-//
-// Rust has no classes; struct, enum, union and trait are the class-like
-// containers. An `impl` block is not one of them: it declares no type, it holds
-// the methods of a type declared elsewhere, so its methods are bound to that
-// type by ReceiverTypeName below.
 var (
-	rustModules   = &Treesitter.TypeSet{Language: tsRust.GetLanguage, Types: []string{"source_file"}}
-	rustClasses   = &Treesitter.TypeSet{Language: tsRust.GetLanguage, Types: []string{"struct_item", "enum_item", "union_item", "trait_item"}}
+	rustModules = &Treesitter.TypeSet{Language: tsRust.GetLanguage, Types: []string{"source_file"}}
+
+	// Rust has no classes; struct, enum, union and trait are the class-like
+	// containers. An `impl` block is not one of them: it declares no type, it
+	// holds the methods of a type declared elsewhere, so its methods are bound
+	// to that type by ReceiverTypeName below.
+	rustClasses = &Treesitter.TypeSet{Language: tsRust.GetLanguage, Types: []string{"struct_item", "enum_item", "union_item", "trait_item"}}
+
 	rustFunctions = &Treesitter.TypeSet{Language: tsRust.GetLanguage, Types: []string{"function_item", "function_signature_item", "method_item"}}
 )
 

--- a/internal/engine/rust/tree_sitter_rust_adapter.go
+++ b/internal/engine/rust/tree_sitter_rust_adapter.go
@@ -113,21 +113,23 @@ func (a *TreeSitterAdapter) EachParamIdent(params *sitter.Node, yield func(strin
 	walk(params)
 }
 
-func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool {
-	return n.Type() == "source_file"
-}
+// These questions are asked on every node of every walk, so they are answered
+// by symbol id rather than by node type name. See
+// internal/engine/treesitter/symbols.go.
+//
+// Rust has no classes; struct, enum, union and trait are the class-like
+// containers. An `impl` block is not one of them: it declares no type, it holds
+// the methods of a type declared elsewhere, so its methods are bound to that
+// type by ReceiverTypeName below.
+var (
+	rustModules   = &Treesitter.TypeSet{Language: tsRust.GetLanguage, Types: []string{"source_file"}}
+	rustClasses   = &Treesitter.TypeSet{Language: tsRust.GetLanguage, Types: []string{"struct_item", "enum_item", "union_item", "trait_item"}}
+	rustFunctions = &Treesitter.TypeSet{Language: tsRust.GetLanguage, Types: []string{"function_item", "function_signature_item", "method_item"}}
+)
 
-func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool {
-	// Rust has no classes; treat struct, enum, union and trait as class-like
-	// containers. An `impl` block is not one of them: it declares no type, it
-	// holds the methods of a type declared elsewhere, so its methods are bound
-	// to that type by ReceiverTypeName below.
-	switch n.Type() {
-	case "struct_item", "enum_item", "union_item", "trait_item":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return rustModules.Has(n) }
+
+func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool { return rustClasses.Has(n) }
 
 // ReceiverTypeName returns the type a method belongs to when it is declared in
 // an `impl` block rather than inside the type itself.
@@ -164,13 +166,7 @@ func lastPathSegment(name string) string {
 	return strings.TrimSpace(name)
 }
 
-func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool {
-	switch n.Type() {
-	case "function_item", "function_signature_item", "method_item":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool { return rustFunctions.Has(n) }
 
 func (a *TreeSitterAdapter) ModuleNameFromPath(path string) string {
 	return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
@@ -227,13 +223,14 @@ func (a *TreeSitterAdapter) EachChildBody(body *sitter.Node, yield func(*sitter.
 // a try_expression, a node distinct from the `?Sized` of a trait bound, so a
 // relaxed bound is never mistaken for a branch.
 var rustDecisions = &Treesitter.DecisionSpec{
-	If:      []string{"if_expression", "if_let_expression", "try_expression"},
-	Else:    []string{"else_clause"},
-	Loop:    []string{"for_expression", "while_expression", "while_let_expression", "loop_expression"},
-	Switch:  []string{"match_expression"},
-	Case:    []string{"match_arm"},
-	Logical: []string{"binary_expression"},
-	Ops:     []string{"&&", "||"},
+	Language: tsRust.GetLanguage,
+	If:       []string{"if_expression", "if_let_expression", "try_expression"},
+	Else:     []string{"else_clause"},
+	Loop:     []string{"for_expression", "while_expression", "while_let_expression", "loop_expression"},
+	Switch:   []string{"match_expression"},
+	Case:     []string{"match_arm"},
+	Logical:  []string{"binary_expression"},
+	Ops:      []string{"&&", "||"},
 }
 
 func (a *TreeSitterAdapter) Decision(n *sitter.Node) Treesitter.DecisionKind {
@@ -410,6 +407,7 @@ func dedup(in []Treesitter.ImportItem) []Treesitter.ImportItem {
 // `const_item` and `static_item` are local declarations: at file scope they
 // declare a member of the module, inside a function they are instructions.
 var rustStatements = &Treesitter.StatementSpec{
+	Language: tsRust.GetLanguage,
 	Statement: []string{
 		"expression_statement", "let_declaration",
 		"if_expression",

--- a/internal/engine/treesitter/decision.go
+++ b/internal/engine/treesitter/decision.go
@@ -73,11 +73,22 @@ type DecisionSpec struct {
 	Logical []string
 	Ops     []string
 
-	once    sync.Once
-	byType  map[string]DecisionKind
-	logical map[string]bool
-	ops     map[string]bool
+	// Language is the grammar these node types belong to, which lets the
+	// classification work on symbol ids instead of node type names. See
+	// symbols.go.
+	Language func() *sitter.Language
+
+	once     sync.Once
+	byType   map[string]DecisionKind
+	logical  map[string]bool
+	ops      map[string]bool
+	bySymbol symbolTable[DecisionKind]
 }
+
+// decLogicalCandidate marks, inside the symbol table only, a node type that may
+// carry a short-circuit operator. It never leaves Classify: what the node holds
+// decides between DecLogical and DecNone.
+const decLogicalCandidate DecisionKind = -1
 
 func (s *DecisionSpec) index() {
 	s.once.Do(func() {
@@ -105,6 +116,18 @@ func (s *DecisionSpec) index() {
 		for _, o := range s.Ops {
 			s.ops[o] = true
 		}
+		if s.Language != nil {
+			// a candidate for a boolean operator wins over the kind its name
+			// would give it, as in Classify below
+			byName := make(map[string]DecisionKind, len(s.byType)+len(s.logical))
+			for t, kind := range s.byType {
+				byName[t] = kind
+			}
+			for t := range s.logical {
+				byName[t] = decLogicalCandidate
+			}
+			s.bySymbol = newSymbolTable(s.Language(), byName)
+		}
 	})
 }
 
@@ -115,18 +138,34 @@ func (s *DecisionSpec) Classify(n *sitter.Node, src []byte) DecisionKind {
 		return DecNone
 	}
 	s.index()
+
+	if s.bySymbol.ready() {
+		kind := s.bySymbol.at(n)
+		if kind == decLogicalCandidate {
+			return s.logicalKind(n, src)
+		}
+		return kind
+	}
+
 	t := n.Type()
 	if s.logical[t] {
-		op := n.ChildByFieldName("operator")
-		if op == nil || !s.ops[nodeText(src, op)] {
-			return DecNone
-		}
-		return DecLogical
+		return s.logicalKind(n, src)
 	}
 	if kind, ok := s.byType[t]; ok {
 		return kind
 	}
 	return DecNone
+}
+
+// logicalKind decides what a candidate for a short-circuit operator is worth:
+// only the operator it carries tells a branch from a bitwise or comparison
+// expression.
+func (s *DecisionSpec) logicalKind(n *sitter.Node, src []byte) DecisionKind {
+	op := n.ChildByFieldName("operator")
+	if op == nil || !s.ops[nodeText(src, op)] {
+		return DecNone
+	}
+	return DecLogical
 }
 
 // LogicalOperator returns the operator carried by a DecLogical node.

--- a/internal/engine/treesitter/decision.go
+++ b/internal/engine/treesitter/decision.go
@@ -80,14 +80,13 @@ type DecisionSpec struct {
 
 	once     sync.Once
 	byType   map[string]DecisionKind
-	logical  map[string]bool
 	ops      map[string]bool
 	bySymbol symbolTable[DecisionKind]
 }
 
-// decLogicalCandidate marks, inside the symbol table only, a node type that may
-// carry a short-circuit operator. It never leaves Classify: what the node holds
-// decides between DecLogical and DecNone.
+// decLogicalCandidate marks a node type that may carry a short-circuit
+// operator. It never leaves Classify: what the node holds decides between
+// DecLogical and DecNone.
 const decLogicalCandidate DecisionKind = -1
 
 func (s *DecisionSpec) index() {
@@ -108,25 +107,17 @@ func (s *DecisionSpec) index() {
 				s.byType[t] = kind
 			}
 		}
-		s.logical = make(map[string]bool, len(s.Logical))
+		// a node type that may carry a boolean operator is a candidate, whatever
+		// kind its name would otherwise give it
 		for _, t := range s.Logical {
-			s.logical[t] = true
+			s.byType[t] = decLogicalCandidate
 		}
 		s.ops = make(map[string]bool, len(s.Ops))
 		for _, o := range s.Ops {
 			s.ops[o] = true
 		}
 		if s.Language != nil {
-			// a candidate for a boolean operator wins over the kind its name
-			// would give it, as in Classify below
-			byName := make(map[string]DecisionKind, len(s.byType)+len(s.logical))
-			for t, kind := range s.byType {
-				byName[t] = kind
-			}
-			for t := range s.logical {
-				byName[t] = decLogicalCandidate
-			}
-			s.bySymbol = newSymbolTable(s.Language(), byName)
+			s.bySymbol = newSymbolTable(s.Language(), s.byType)
 		}
 	})
 }
@@ -139,22 +130,20 @@ func (s *DecisionSpec) Classify(n *sitter.Node, src []byte) DecisionKind {
 	}
 	s.index()
 
-	if s.bySymbol.ready() {
-		kind := s.bySymbol.at(n)
-		if kind == decLogicalCandidate {
-			return s.logicalKind(n, src)
-		}
-		return kind
-	}
-
-	t := n.Type()
-	if s.logical[t] {
+	kind := s.kindOf(n)
+	if kind == decLogicalCandidate {
 		return s.logicalKind(n, src)
 	}
-	if kind, ok := s.byType[t]; ok {
-		return kind
+	return kind
+}
+
+// kindOf reads the kind declared for the node's type: by symbol id when the
+// adapter named the grammar, by node type name otherwise.
+func (s *DecisionSpec) kindOf(n *sitter.Node) DecisionKind {
+	if s.bySymbol.ready() {
+		return s.bySymbol.at(n)
 	}
-	return DecNone
+	return s.byType[n.Type()]
 }
 
 // logicalKind decides what a candidate for a short-circuit operator is worth:

--- a/internal/engine/treesitter/lines.go
+++ b/internal/engine/treesitter/lines.go
@@ -7,15 +7,15 @@ import (
 
 // LineCache splits a source into its lines once.
 //
-// The extractors that read the text of a scope (method calls, operators) are
-// called once per function, and each of them received the whole file. Splitting
-// it again for every function copied the file as many times as it holds
-// functions, which is what made a large file cost far more than its size: a
-// 194 KB stub took three times longer per byte than the rest of a project.
+// The extractors that read the text of a scope are called once per function and
+// each of them receives the whole file. Splitting it again for every function
+// copied the file as many times as it holds functions, which is what made a
+// large file cost far more than its size.
 //
-// An adapter serves one file, so caching on the source it is handed is enough.
-// The identity of the slice is what is compared, not its content: the callers
-// pass the same slice every time.
+// An adapter serves one file, so remembering the last source is enough. What is
+// compared is the identity of the slice, not its content: the callers hand over
+// the same slice every time, and a different one must not be answered with the
+// lines of the previous file.
 type LineCache struct {
 	mutex sync.Mutex
 	src   []byte
@@ -28,21 +28,12 @@ func (c *LineCache) Lines(src []byte) []string {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	if c.sameSource(src) {
-		return c.lines
+	same := c.lines != nil && len(c.src) == len(src) &&
+		(len(src) == 0 || &c.src[0] == &src[0])
+	if !same {
+		c.src = src
+		c.lines = strings.Split(string(src), "\n")
 	}
 
-	c.src = src
-	c.lines = strings.Split(string(src), "\n")
 	return c.lines
-}
-
-func (c *LineCache) sameSource(src []byte) bool {
-	if c.lines == nil || len(c.src) != len(src) {
-		return false
-	}
-	if len(src) == 0 {
-		return true
-	}
-	return &c.src[0] == &src[0]
 }

--- a/internal/engine/treesitter/lines.go
+++ b/internal/engine/treesitter/lines.go
@@ -1,0 +1,48 @@
+package treesitter
+
+import (
+	"strings"
+	"sync"
+)
+
+// LineCache splits a source into its lines once.
+//
+// The extractors that read the text of a scope (method calls, operators) are
+// called once per function, and each of them received the whole file. Splitting
+// it again for every function copied the file as many times as it holds
+// functions, which is what made a large file cost far more than its size: a
+// 194 KB stub took three times longer per byte than the rest of a project.
+//
+// An adapter serves one file, so caching on the source it is handed is enough.
+// The identity of the slice is what is compared, not its content: the callers
+// pass the same slice every time.
+type LineCache struct {
+	mutex sync.Mutex
+	src   []byte
+	lines []string
+}
+
+// Lines returns src split on newlines, reusing the previous split when src is
+// the very same slice.
+func (c *LineCache) Lines(src []byte) []string {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.sameSource(src) {
+		return c.lines
+	}
+
+	c.src = src
+	c.lines = strings.Split(string(src), "\n")
+	return c.lines
+}
+
+func (c *LineCache) sameSource(src []byte) bool {
+	if c.lines == nil || len(c.src) != len(src) {
+		return false
+	}
+	if len(src) == 0 {
+		return true
+	}
+	return &c.src[0] == &src[0]
+}

--- a/internal/engine/treesitter/lines.go
+++ b/internal/engine/treesitter/lines.go
@@ -8,9 +8,9 @@ import (
 // LineCache splits a source into its lines once.
 //
 // The extractors that read the text of a scope are called once per function and
-// each of them receives the whole file. Splitting it again for every function
-// copied the file as many times as it holds functions, which is what made a
-// large file cost far more than its size.
+// each of them receives the whole file. Splitting it for every function would
+// copy the file as many times as it holds functions, which is what makes a large
+// file cost far more than its size.
 //
 // An adapter serves one file, so remembering the last source is enough. What is
 // compared is the identity of the slice, not its content: the callers hand over

--- a/internal/engine/treesitter/statement.go
+++ b/internal/engine/treesitter/statement.go
@@ -73,8 +73,14 @@ type StatementSpec struct {
 	// instruction only inside a function body.
 	LocalDeclaration []string
 
-	once   sync.Once
-	byType map[string]StatementKind
+	// Language is the grammar these node types belong to, which lets the
+	// classification work on symbol ids instead of node type names. See
+	// symbols.go.
+	Language func() *sitter.Language
+
+	once     sync.Once
+	byType   map[string]StatementKind
+	bySymbol symbolTable[StatementKind]
 }
 
 func (s *StatementSpec) index() {
@@ -86,6 +92,9 @@ func (s *StatementSpec) index() {
 		for _, t := range s.LocalDeclaration {
 			s.byType[t] = IsLocalDeclaration
 		}
+		if s.Language != nil {
+			s.bySymbol = newSymbolTable(s.Language(), s.byType)
+		}
 	})
 }
 
@@ -95,6 +104,9 @@ func (s *StatementSpec) Classify(n *sitter.Node) StatementKind {
 		return NotAStatement
 	}
 	s.index()
+	if s.bySymbol.ready() {
+		return s.bySymbol.at(n)
+	}
 	return s.byType[n.Type()]
 }
 

--- a/internal/engine/treesitter/symbols.go
+++ b/internal/engine/treesitter/symbols.go
@@ -9,9 +9,9 @@ import (
 // Classifying a node by the name of its type is what every walk does on every
 // node, several times: is it a statement, a decision, a class, a function, a
 // scope boundary. Asking `Node.Type()` is the most expensive way to ask: it
-// crosses into C and copies the name into a fresh Go string, every time, so the
-// walks spent a fifth of the analysis there and fed the garbage collector with
-// strings nobody keeps.
+// crosses into C and copies the name into a fresh Go string, every time, which
+// costs a fifth of an analysis and feeds the garbage collector with strings
+// nobody keeps.
 //
 // The grammar answers the same question with an integer. Every node carries a
 // symbol id, the ids of one language form a small dense range, and

--- a/internal/engine/treesitter/symbols.go
+++ b/internal/engine/treesitter/symbols.go
@@ -1,0 +1,107 @@
+package treesitter
+
+import (
+	"sync"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// Classifying a node by the name of its type is what every walk does on every
+// node, several times: is it a statement, a decision, a class, a function, a
+// scope boundary. Asking `Node.Type()` is the most expensive way to ask: it
+// crosses into C and copies the name into a fresh Go string, every time, so the
+// walks spent a fifth of the analysis there and fed the garbage collector with
+// strings nobody keeps.
+//
+// The grammar answers the same question with an integer. Every node carries a
+// symbol id, the ids of one language form a small dense range, and
+// `Node.Type()` is defined as the name of the node's symbol. Turning the node
+// names an adapter declares into a table indexed by that id therefore keeps the
+// exact same answers, while making a classification an array lookup with no
+// allocation and no string comparison.
+//
+// A grammar an adapter does not declare a language for still works: the tables
+// stay empty and the classification falls back to the node type name.
+
+// symbolTable maps the symbol ids of one grammar onto a value. The zero value of
+// T is the answer for any id the adapter said nothing about, which is what a
+// comparison against a list of node type names would have returned.
+type symbolTable[T any] struct {
+	byID []T
+}
+
+// newSymbolTable turns a mapping keyed by node type name into one keyed by
+// symbol id. A name the grammar does not know simply never matches.
+func newSymbolTable[T any](lang *sitter.Language, byName map[string]T) symbolTable[T] {
+	if lang == nil || len(byName) == 0 {
+		return symbolTable[T]{}
+	}
+
+	count := int(lang.SymbolCount())
+	table := symbolTable[T]{byID: make([]T, count)}
+	for id := 0; id < count; id++ {
+		if value, ok := byName[lang.SymbolName(sitter.Symbol(id))]; ok {
+			table.byID[id] = value
+		}
+	}
+	return table
+}
+
+func (t symbolTable[T]) ready() bool {
+	return len(t.byID) > 0
+}
+
+// at returns the value declared for the node's type. Ids outside the table are
+// the built-in symbols a grammar file does not describe (ERROR carries 65535),
+// and no adapter declares those.
+func (t symbolTable[T]) at(n *sitter.Node) T {
+	var none T
+	if n == nil {
+		return none
+	}
+	id := int(n.Symbol())
+	if id < 0 || id >= len(t.byID) {
+		return none
+	}
+	return t.byID[id]
+}
+
+// TypeSet answers whether a node is one of the node types of a grammar, by
+// symbol id rather than by name. Adapters use it for the structural questions
+// asked on every node of every walk.
+type TypeSet struct {
+	// Language is the grammar the node types belong to. It is a function
+	// because a grammar is loaded by a call, and a package-level set must not
+	// depend on the initialization order of two packages.
+	Language func() *sitter.Language
+	// Types lists the node types of the set.
+	Types []string
+
+	once   sync.Once
+	table  symbolTable[bool]
+	byName map[string]bool
+}
+
+func (s *TypeSet) index() {
+	s.once.Do(func() {
+		s.byName = make(map[string]bool, len(s.Types))
+		for _, t := range s.Types {
+			s.byName[t] = true
+		}
+		if s.Language != nil {
+			s.table = newSymbolTable(s.Language(), s.byName)
+		}
+	})
+}
+
+// Has reports whether the node is one of the declared types.
+func (s *TypeSet) Has(n *sitter.Node) bool {
+	if n == nil {
+		return false
+	}
+	s.index()
+	if s.table.ready() {
+		return s.table.at(n)
+	}
+	return s.byName[n.Type()]
+}

--- a/internal/engine/treesitter/visitor.go
+++ b/internal/engine/treesitter/visitor.go
@@ -27,10 +27,18 @@ type Visitor struct {
 	// file has been visited, because a method may be declared before its type.
 	receiverMethods []receiverMethod
 
-	// logicalLines holds the 1-based line numbers on which a statement starts.
-	// LLOC at every level (file, class, function) is the number of such lines
-	// in the scope's range.
-	logicalLines map[int]bool
+	// logicalLines tells, for each line of the file, whether a statement starts
+	// on it. LLOC at every level (file, class, function) is the number of such
+	// lines in the scope's range, read from llocTotals.
+	logicalLines []bool
+	// llocTotals holds the running total of logical lines, so that the count
+	// over a scope is a subtraction instead of a walk over the whole file.
+	llocTotals []int32
+	// lineIndex holds LOC, CLOC and NCLOC per line, scanned once for the file.
+	lineIndex *engine.LineIndex
+	// collected tells that the file-wide passes have run: they belong to the
+	// first Visit call, the one receiving the root node.
+	collected bool
 }
 
 // receiverMethod is a method waiting to be attached to the class of its
@@ -62,7 +70,9 @@ func (v *Visitor) collectLogicalLines(node *sitter.Node) {
 			counts = inFunction
 		}
 		if counts {
-			v.logicalLines[int(n.StartPoint().Row)+1] = true
+			if line := int(n.StartPoint().Row); line < len(v.logicalLines) {
+				v.logicalLines[line] = true
+			}
 		}
 
 		childInClass, childInFunction := inClass, inFunction
@@ -86,13 +96,32 @@ func (v *Visitor) collectLogicalLines(node *sitter.Node) {
 // countLogicalLines returns the number of logical lines within the 1-based
 // inclusive line range.
 func (v *Visitor) countLogicalLines(start, end int) int {
-	cnt := 0
-	for line := range v.logicalLines {
-		if line >= start && line <= end {
-			cnt++
-		}
+	if len(v.llocTotals) == 0 {
+		return 0
 	}
-	return cnt
+	if start < 1 {
+		start = 1
+	}
+	if end > len(v.logicalLines) {
+		end = len(v.logicalLines)
+	}
+	if end < start {
+		return 0
+	}
+	return int(v.llocTotals[end] - v.llocTotals[start-1])
+}
+
+// indexLogicalLines turns the lines carrying a statement into running totals,
+// once the whole tree has been walked.
+func (v *Visitor) indexLogicalLines() {
+	v.llocTotals = make([]int32, len(v.logicalLines)+1)
+	for i, carries := range v.logicalLines {
+		total := v.llocTotals[i]
+		if carries {
+			total++
+		}
+		v.llocTotals[i+1] = total
+	}
 }
 
 // locationOf converts a tree-sitter node position into a 1-based file
@@ -124,13 +153,16 @@ func NewVisitor(ad LangAdapter, path string, src []byte) *Visitor {
 	lines := engine.SplitSourceLines(src)
 	mod := ad.ModuleNameFromPath(filepath.Base(path))
 
-	return &Visitor{
+	v := &Visitor{
 		ad:     ad,
 		file:   &pb.File{Path: path, ProgrammingLanguage: "", Stmts: engine.FactoryStmts(), LinesOfCode: &pb.LinesOfCode{LinesOfCode: int32(len(lines))}},
 		ns:     &pb.StmtNamespace{Name: &pb.Name{Short: mod, Qualified: mod}, Stmts: engine.FactoryStmts(), LinesOfCode: &pb.LinesOfCode{}},
 		lines:  lines,
 		joined: []byte(strings.Join(lines, "\n")),
 	}
+	v.lineIndex = engine.NewLineIndex(lines, v.commentSyntax())
+
+	return v
 }
 
 // commentSyntax returns the comment syntax declared by the adapter, or a
@@ -146,7 +178,7 @@ func (v *Visitor) commentSyntax() engine.CommentSyntax {
 // physical size, how many of those lines are comments, how many hold code, and
 // how many carry a statement.
 func (v *Visitor) linesOfCodeIn(start, end int) *pb.LinesOfCode {
-	loc := engine.CountLinesOfCode(v.lines, start, end, v.commentSyntax())
+	loc := v.lineIndex.Count(start, end)
 	loc.LogicalLinesOfCode = int32(v.countLogicalLines(start, end))
 	return loc
 }
@@ -316,9 +348,11 @@ func (v *Visitor) Visit(node *sitter.Node) {
 	// The first call receives the root node: collect logical lines and the
 	// file-level decisions (a script can branch outside of any function) for
 	// the whole file before descending.
-	if v.logicalLines == nil {
-		v.logicalLines = map[int]bool{}
+	if !v.collected {
+		v.collected = true
+		v.logicalLines = make([]bool, len(v.lines))
 		v.collectLogicalLines(node)
+		v.indexLogicalLines()
 		v.collectDecisions(node, v.file.Stmts)
 	}
 

--- a/internal/engine/treesitter/visitor.go
+++ b/internal/engine/treesitter/visitor.go
@@ -14,6 +14,10 @@ type Visitor struct {
 	file  *pb.File
 	ns    *pb.StmtNamespace
 	lines []string
+	// joined is the source rebuilt from lines, computed once: the adapters that
+	// extract operators, operands or method calls from the source text all need
+	// it, and rebuilding it per scope copied the whole file for every function.
+	joined []byte
 
 	classStk []*pb.StmtClass
 	funcStk  []*pb.StmtFunction
@@ -121,10 +125,11 @@ func NewVisitor(ad LangAdapter, path string, src []byte) *Visitor {
 	mod := ad.ModuleNameFromPath(filepath.Base(path))
 
 	return &Visitor{
-		ad:    ad,
-		file:  &pb.File{Path: path, ProgrammingLanguage: "", Stmts: engine.FactoryStmts(), LinesOfCode: &pb.LinesOfCode{LinesOfCode: int32(len(lines))}},
-		ns:    &pb.StmtNamespace{Name: &pb.Name{Short: mod, Qualified: mod}, Stmts: engine.FactoryStmts(), LinesOfCode: &pb.LinesOfCode{}},
-		lines: lines,
+		ad:     ad,
+		file:   &pb.File{Path: path, ProgrammingLanguage: "", Stmts: engine.FactoryStmts(), LinesOfCode: &pb.LinesOfCode{LinesOfCode: int32(len(lines))}},
+		ns:     &pb.StmtNamespace{Name: &pb.Name{Short: mod, Qualified: mod}, Stmts: engine.FactoryStmts(), LinesOfCode: &pb.LinesOfCode{}},
+		lines:  lines,
+		joined: []byte(strings.Join(lines, "\n")),
 	}
 }
 
@@ -471,7 +476,7 @@ func (v *Visitor) Visit(node *sitter.Node) {
 		if va, ok := v.ad.(interface {
 			ExtractOperatorsOperands(src []byte, startLine, endLine int) (ops []string, operands []string)
 		}); ok {
-			ops, opr := va.ExtractOperatorsOperands([]byte(strings.Join(v.lines, "\n")), nodeStart, nodeEnd)
+			ops, opr := va.ExtractOperatorsOperands(v.joined, nodeStart, nodeEnd)
 			for _, o := range ops {
 				fn.Operators = append(fn.Operators, &pb.StmtOperator{Name: o})
 			}
@@ -483,7 +488,7 @@ func (v *Visitor) Visit(node *sitter.Node) {
 		if mc, ok := v.ad.(interface {
 			ExtractMethodCalls(src []byte, startLine, endLine int) []string
 		}); ok {
-			calls := mc.ExtractMethodCalls([]byte(strings.Join(v.lines, "\n")), nodeStart, nodeEnd)
+			calls := mc.ExtractMethodCalls(v.joined, nodeStart, nodeEnd)
 			for _, m := range calls {
 				fn.MethodCalls = append(fn.MethodCalls, &pb.StmtMethodCall{Name: m})
 			}

--- a/internal/engine/treesitter/visitor.go
+++ b/internal/engine/treesitter/visitor.go
@@ -14,9 +14,10 @@ type Visitor struct {
 	file  *pb.File
 	ns    *pb.StmtNamespace
 	lines []string
-	// joined is the source rebuilt from lines, computed once: the adapters that
-	// extract operators, operands or method calls from the source text all need
-	// it, and rebuilding it per scope copied the whole file for every function.
+	// joined is the source rebuilt from lines. The adapters that extract
+	// operators, operands or method calls from the source text are called once
+	// per scope and all need it, so it is built once: building it per scope
+	// would copy the whole file for every function it holds.
 	joined []byte
 
 	classStk []*pb.StmtClass

--- a/internal/engine/typescript/tree_sitter_typescript_adapter.go
+++ b/internal/engine/typescript/tree_sitter_typescript_adapter.go
@@ -39,29 +39,23 @@ func (a *TreeSitterAdapter) ensureRoot(src []byte) (*sitter.Node, []byte) {
 	return a.root, source
 }
 
-func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return n.Type() == "program" }
+// These four questions are asked on every node of every walk, so they are
+// answered by symbol id rather than by node type name. See
+// internal/engine/treesitter/symbols.go.
+var (
+	tsModules    = &Treesitter.TypeSet{Language: tsTsx.GetLanguage, Types: []string{"program"}}
+	tsClasses    = &Treesitter.TypeSet{Language: tsTsx.GetLanguage, Types: []string{"class_declaration", "abstract_class_declaration", "enum_declaration"}}
+	tsInterfaces = &Treesitter.TypeSet{Language: tsTsx.GetLanguage, Types: []string{"interface_declaration"}}
+	tsFunctions  = &Treesitter.TypeSet{Language: tsTsx.GetLanguage, Types: []string{"function_declaration", "method_definition", "generator_function_declaration", "arrow_function"}}
+)
 
-func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool {
-	switch n.Type() {
-	case "class_declaration", "abstract_class_declaration", "enum_declaration":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsModule(n *sitter.Node) bool { return tsModules.Has(n) }
 
-func (a *TreeSitterAdapter) IsInterface(n *sitter.Node) bool {
-	return n.Type() == "interface_declaration"
-}
+func (a *TreeSitterAdapter) IsClass(n *sitter.Node) bool { return tsClasses.Has(n) }
 
-func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool {
-	switch n.Type() {
-	case "function_declaration", "method_definition", "generator_function_declaration":
-		return true
-	case "arrow_function":
-		return true
-	}
-	return false
-}
+func (a *TreeSitterAdapter) IsInterface(n *sitter.Node) bool { return tsInterfaces.Has(n) }
+
+func (a *TreeSitterAdapter) IsFunction(n *sitter.Node) bool { return tsFunctions.Has(n) }
 
 func (a *TreeSitterAdapter) NodeName(n *sitter.Node) string {
 	if a.src == nil || n == nil {
@@ -211,16 +205,17 @@ func (a *TreeSitterAdapter) EachChildBody(body *sitter.Node, yield func(*sitter.
 // if is counted on its own. `??` is deliberately not a logical operator here,
 // for the same reason as in PHP.
 var tsDecisions = &Treesitter.DecisionSpec{
-	If:      []string{"if_statement"},
-	Else:    []string{"else_clause"},
-	Loop:    []string{"for_statement", "for_in_statement", "while_statement", "do_statement"},
-	Switch:  []string{"switch_statement"},
-	Case:    []string{"switch_case"},
-	Default: []string{"switch_default"},
-	Catch:   []string{"catch_clause"},
-	Ternary: []string{"ternary_expression"},
-	Logical: []string{"binary_expression"},
-	Ops:     []string{"&&", "||"},
+	Language: tsTsx.GetLanguage,
+	If:       []string{"if_statement"},
+	Else:     []string{"else_clause"},
+	Loop:     []string{"for_statement", "for_in_statement", "while_statement", "do_statement"},
+	Switch:   []string{"switch_statement"},
+	Case:     []string{"switch_case"},
+	Default:  []string{"switch_default"},
+	Catch:    []string{"catch_clause"},
+	Ternary:  []string{"ternary_expression"},
+	Logical:  []string{"binary_expression"},
+	Ops:      []string{"&&", "||"},
 }
 
 func (a *TreeSitterAdapter) Decision(n *sitter.Node) Treesitter.DecisionKind {
@@ -370,6 +365,7 @@ func (a *TreeSitterAdapter) importsFromExportStatement(n *sitter.Node) []Treesit
 // runs. An `else if` is spelled as an `else_clause` holding an `if_statement`,
 // so the nested if is what counts.
 var tsStatements = &Treesitter.StatementSpec{
+	Language: tsTsx.GetLanguage,
 	Statement: []string{
 		"expression_statement",
 		"lexical_declaration", "variable_declaration",

--- a/internal/engine/util.go
+++ b/internal/engine/util.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -458,7 +457,42 @@ func CreateTestFileWithCode(parser Engine, fileContent string) (*pb.File, error)
 	return parser.Parse(f.Name())
 }
 
-var regForNamespacePart = regexp.MustCompile("[^A-Za-z0-9]+")
+// splitNamespaceParts cuts a namespace on its separators, a separator being a
+// run of characters that are neither a letter nor a digit, and returns the first
+// one along with the parts.
+//
+// This is what a "[^A-Za-z0-9]+" regular expression does, written by hand
+// because the aggregation asks it of every namespace of every scope, and the
+// regular expression engine was the longest part of that phase. Bytes are enough
+// to agree with the expression: every byte of a multi-byte character is outside
+// the alphanumeric range, so the two see the same separators at the same places.
+func splitNamespaceParts(namespace string) (separator string, parts []string) {
+	isPart := func(c byte) bool {
+		return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+	}
+
+	parts = make([]string, 0, 8)
+	start := 0
+	for i := 0; i < len(namespace); {
+		if isPart(namespace[i]) {
+			i++
+			continue
+		}
+		end := i
+		for end < len(namespace) && !isPart(namespace[end]) {
+			end++
+		}
+		if separator == "" {
+			separator = namespace[i:end]
+		}
+		parts = append(parts, namespace[start:i])
+		start = end
+		i = end
+	}
+	parts = append(parts, namespace[start:])
+
+	return separator, parts
+}
 
 // Keep only n levels in namespace
 func ReduceDepthOfNamespace(namespace string, depth int) string {
@@ -469,8 +503,7 @@ func ReduceDepthOfNamespace(namespace string, depth int) string {
 		depth += 1
 	}
 
-	separator := regForNamespacePart.FindString(namespace)
-	parts := regForNamespacePart.Split(namespace, -1)
+	separator, parts := splitNamespaceParts(namespace)
 
 	if depth >= len(parts) {
 		return strings.Replace(namespace, "githubcom", "github.com", -1)

--- a/internal/engine/util.go
+++ b/internal/engine/util.go
@@ -462,10 +462,11 @@ func CreateTestFileWithCode(parser Engine, fileContent string) (*pb.File, error)
 // one along with the parts.
 //
 // This is what a "[^A-Za-z0-9]+" regular expression does, written by hand
-// because the aggregation asks it of every namespace of every scope, and the
-// regular expression engine was the longest part of that phase. Bytes are enough
-// to agree with the expression: every byte of a multi-byte character is outside
-// the alphanumeric range, so the two see the same separators at the same places.
+// because the aggregation asks it of every namespace of every scope, enough for
+// the regular expression engine to be the longest part of that phase. Bytes are
+// enough to agree with the expression: every byte of a multi-byte character is
+// outside the alphanumeric range, so the two see the same separators at the same
+// places.
 func splitNamespaceParts(namespace string) (separator string, parts []string) {
 	isPart := func(c byte) bool {
 		return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')

--- a/internal/engine/util_test.go
+++ b/internal/engine/util_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -357,6 +358,44 @@ func TestReduceDepthOfNamespace(t *testing.T) {
 	// This should return the full namespace since depth >= parts length
 	if !strings.Contains(result, "github.com") {
 		t.Errorf("ReduceDepthOfNamespace with github.com should preserve github.com, got %q", result)
+	}
+}
+
+// splitNamespaceParts replaced a "[^A-Za-z0-9]+" regular expression, which the
+// aggregation ran on every namespace of every scope. It has to answer exactly
+// what that expression answered, separators included, or namespaces would be
+// grouped differently.
+func TestSplitNamespaceParts(t *testing.T) {
+	reference := regexp.MustCompile("[^A-Za-z0-9]+")
+
+	for _, namespace := range []string{
+		"",
+		"simple",
+		"com.example.package",
+		"App\\Component\\Github",
+		"github.com/user/repo",
+		"/leading/separator",
+		"trailing.separator.",
+		"double..separator",
+		"mixed_-.separators",
+		"héllo.wörld",
+		"...",
+		"a1.b2.c3",
+	} {
+		separator, parts := splitNamespaceParts(namespace)
+
+		if expected := reference.FindString(namespace); separator != expected {
+			t.Errorf("splitNamespaceParts(%q) separator = %q, expected %q", namespace, separator, expected)
+		}
+		expectedParts := reference.Split(namespace, -1)
+		if len(parts) != len(expectedParts) {
+			t.Fatalf("splitNamespaceParts(%q) = %q, expected %q", namespace, parts, expectedParts)
+		}
+		for i := range parts {
+			if parts[i] != expectedParts[i] {
+				t.Errorf("splitNamespaceParts(%q) part %d = %q, expected %q", namespace, i, parts[i], expectedParts[i])
+			}
+		}
 	}
 }
 

--- a/internal/engine/util_test.go
+++ b/internal/engine/util_test.go
@@ -361,10 +361,9 @@ func TestReduceDepthOfNamespace(t *testing.T) {
 	}
 }
 
-// splitNamespaceParts replaced a "[^A-Za-z0-9]+" regular expression, which the
-// aggregation ran on every namespace of every scope. It has to answer exactly
-// what that expression answered, separators included, or namespaces would be
-// grouped differently.
+// splitNamespaceParts has to answer exactly what a "[^A-Za-z0-9]+" regular
+// expression answers, separators included, or namespaces would be grouped
+// differently. The expression itself is the reference.
 func TestSplitNamespaceParts(t *testing.T) {
 	reference := regexp.MustCompile("[^A-Za-z0-9]+")
 

--- a/internal/file/finder.go
+++ b/internal/file/finder.go
@@ -84,13 +84,8 @@ func (r Finder) Search(fileExtension string) FileList {
 	result.FilesByDirectory = make(map[string][]string)
 	result.Files = []string{}
 
-	// Pre-compile exclude patterns once
-	compiledExcludes := make([]*regexp.Regexp, 0, len(r.Configuration.ExcludePatterns))
-	for _, pattern := range r.Configuration.ExcludePatterns {
-		if re, err := regexp.Compile(pattern); err == nil {
-			compiledExcludes = append(compiledExcludes, re)
-		}
-	}
+	excludes := compileExcludes(r.Configuration.ExcludePatterns)
+	compiledExcludes := excludes.all
 
 	projectRoot := r.resolveProjectRoot()
 
@@ -143,13 +138,8 @@ func (r Finder) SearchMultiple(extensions []string) map[string]FileList {
 		}
 	}
 
-	// Pre-compile exclude patterns once
-	compiledExcludes := make([]*regexp.Regexp, 0, len(r.Configuration.ExcludePatterns))
-	for _, pattern := range r.Configuration.ExcludePatterns {
-		if re, err := regexp.Compile(pattern); err == nil {
-			compiledExcludes = append(compiledExcludes, re)
-		}
-	}
+	excludes := compileExcludes(r.Configuration.ExcludePatterns)
+	compiledExcludes := excludes.all
 
 	projectRoot := r.resolveProjectRoot()
 
@@ -176,7 +166,17 @@ func (r Finder) SearchMultiple(extensions []string) map[string]FileList {
 
 		// Single walk for all extensions
 		filepath.WalkDir(srcPath, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				// An excluded directory is not descended into: reading a
+				// vendor tree, a build cache or a .git directory only to
+				// discard every file it holds is the most expensive part of
+				// the discovery on a real project.
+				if path != srcPath && excludes.prunesDirectory(path, projectRoot, srcPath) {
+					return filepath.SkipDir
+				}
 				return nil
 			}
 			ext := filepath.Ext(path)
@@ -209,6 +209,61 @@ func MergeFileLists(lists ...FileList) FileList {
 		}
 	}
 	return result
+}
+
+// excludeMatcher holds the compiled exclude patterns, and among them the ones
+// that can decide the fate of a whole directory during a walk.
+type excludeMatcher struct {
+	all []*regexp.Regexp
+	// prunable holds the patterns that match a prefix of the path, so that
+	// matching a directory proves that every file under it matches too. A
+	// pattern anchored on the end of the path ("$", "\z") is not one of them:
+	// "/vendor/" excludes everything under vendor, but "_test\.php$" says
+	// nothing about the directory holding the file.
+	prunable []*regexp.Regexp
+}
+
+func compileExcludes(patterns []string) excludeMatcher {
+	m := excludeMatcher{
+		all:      make([]*regexp.Regexp, 0, len(patterns)),
+		prunable: make([]*regexp.Regexp, 0, len(patterns)),
+	}
+	for _, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			continue
+		}
+		m.all = append(m.all, re)
+		if !strings.Contains(pattern, "$") && !strings.Contains(pattern, `\z`) {
+			m.prunable = append(m.prunable, re)
+		}
+	}
+	return m
+}
+
+// prunesDirectory reports whether a directory can be skipped whole. It is only
+// true when a prefix pattern matches the directory path itself, which makes it
+// match every path below it: skipping is then exactly equivalent to excluding
+// each of those files one by one.
+func (m excludeMatcher) prunesDirectory(dir, projectRoot, sourceRoot string) bool {
+	if len(m.prunable) == 0 {
+		return false
+	}
+	target, ok := relativeTo(projectRoot, dir)
+	if !ok {
+		if target, ok = relativeTo(sourceRoot, dir); !ok {
+			target = dir
+		}
+	}
+	// patterns are written with delimiters ("/vendor/"), so the directory is
+	// matched as the prefix it is
+	target += "/"
+	for _, re := range m.prunable {
+		if re.MatchString(target) {
+			return true
+		}
+	}
+	return false
 }
 
 // isExcluded reports whether a discovered file must be skipped. Exclude

--- a/internal/file/finder.go
+++ b/internal/file/finder.go
@@ -85,7 +85,6 @@ func (r Finder) Search(fileExtension string) FileList {
 	result.Files = []string{}
 
 	excludes := compileExcludes(r.Configuration.ExcludePatterns)
-	compiledExcludes := excludes.all
 
 	projectRoot := r.resolveProjectRoot()
 
@@ -102,7 +101,7 @@ func (r Finder) Search(fileExtension string) FileList {
 
 		// deal with excluded files
 		for _, file := range matches {
-			if isExcluded(file, projectRoot, path, compiledExcludes) {
+			if isExcluded(file, projectRoot, path, excludes) {
 				continue
 			}
 
@@ -139,7 +138,6 @@ func (r Finder) SearchMultiple(extensions []string) map[string]FileList {
 	}
 
 	excludes := compileExcludes(r.Configuration.ExcludePatterns)
-	compiledExcludes := excludes.all
 
 	projectRoot := r.resolveProjectRoot()
 
@@ -154,7 +152,7 @@ func (r Finder) SearchMultiple(extensions []string) map[string]FileList {
 		if !info.IsDir() {
 			ext := filepath.Ext(srcPath)
 			if extSet[ext] {
-				if !isExcluded(srcPath, projectRoot, srcPath, compiledExcludes) {
+				if !isExcluded(srcPath, projectRoot, srcPath, excludes) {
 					fl := results[ext]
 					fl.Files = append(fl.Files, srcPath)
 					fl.FilesByDirectory[srcPath] = append(fl.FilesByDirectory[srcPath], srcPath)
@@ -183,7 +181,7 @@ func (r Finder) SearchMultiple(extensions []string) map[string]FileList {
 			if !extSet[ext] {
 				return nil
 			}
-			if isExcluded(path, projectRoot, srcPath, compiledExcludes) {
+			if isExcluded(path, projectRoot, srcPath, excludes) {
 				return nil
 			}
 			fl := results[ext]
@@ -279,14 +277,14 @@ func (m excludeMatcher) prunesDirectory(dir, projectRoot, sourceRoot string) boo
 // When the file lies outside the project root, the path relative to the
 // analyzed source root is used instead, and as a last resort the absolute
 // path.
-func isExcluded(file, projectRoot, sourceRoot string, compiledExcludes []*regexp.Regexp) bool {
+func isExcluded(file, projectRoot, sourceRoot string, excludes excludeMatcher) bool {
 	target, ok := relativeTo(projectRoot, file)
 	if !ok {
 		if target, ok = relativeTo(sourceRoot, file); !ok {
 			target = file
 		}
 	}
-	for _, re := range compiledExcludes {
+	for _, re := range excludes.all {
 		if re.MatchString(target) {
 			return true
 		}

--- a/internal/file/finder_test.go
+++ b/internal/file/finder_test.go
@@ -269,6 +269,49 @@ func TestFinder_SearchMultiple(t *testing.T) {
 		}
 	})
 
+	// An excluded directory is skipped whole instead of being walked to throw
+	// each of its files away afterwards. The result must not change, whatever
+	// the shape of the pattern.
+	t.Run("skips an excluded directory without changing the result", func(t *testing.T) {
+		base := t.TempDir()
+		vendor := filepath.Join(base, "vendor", "lib", "deep")
+		_ = os.MkdirAll(vendor, 0o777)
+		_ = os.WriteFile(filepath.Join(base, "main.go"), []byte("package main\n"), 0o644)
+		_ = os.WriteFile(filepath.Join(vendor, "dep.go"), []byte("package lib\n"), 0o644)
+
+		finder := Finder{Configuration: configuration.Configuration{
+			SourcesToAnalyzePath: []string{base},
+			ExcludePatterns:      []string{"/vendor/"},
+		}}
+		finder.projectRoot = base
+		results := finder.SearchMultiple([]string{".go"})
+
+		if len(results[".go"].Files) != 1 {
+			t.Fatalf("Expected 1 .go file (vendor pruned), got %d (%v)", len(results[".go"].Files), results[".go"].Files)
+		}
+	})
+
+	t.Run("keeps a directory whose pattern is anchored on the end of the path", func(t *testing.T) {
+		// "/tmp/$" excludes a file named tmp, not the content of a directory
+		// named tmp: pruning on such a pattern would drop files the
+		// file-by-file filter keeps.
+		base := t.TempDir()
+		tmp := filepath.Join(base, "tmp")
+		_ = os.MkdirAll(tmp, 0o777)
+		_ = os.WriteFile(filepath.Join(tmp, "kept.go"), []byte("package tmp\n"), 0o644)
+
+		finder := Finder{Configuration: configuration.Configuration{
+			SourcesToAnalyzePath: []string{base},
+			ExcludePatterns:      []string{"/tmp/$"},
+		}}
+		finder.projectRoot = base
+		results := finder.SearchMultiple([]string{".go"})
+
+		if len(results[".go"].Files) != 1 {
+			t.Fatalf("Expected 1 .go file (end-anchored pattern must not prune), got %d (%v)", len(results[".go"].Files), results[".go"].Files)
+		}
+	})
+
 	t.Run("should use SearchMultiple cache in Search", func(t *testing.T) {
 		base := t.TempDir()
 		_ = os.WriteFile(filepath.Join(base, "main.go"), []byte("package main\n"), 0o644)

--- a/internal/report/html_report_generator.go
+++ b/internal/report/html_report_generator.go
@@ -194,58 +194,56 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 // its risks, its communities, its dependencies.
 func (v *HtmlReportGenerator) prepareScopeData(scope scopeDef, files []*pb.File) *cachedLangData {
 	cd := &cachedLangData{}
-	{
-		dict := NewStringDictionary()
+	dict := NewStringDictionary()
 
-		cd.filesJSON = buildFilesJSONPruned(files, scope.Keep)
+	cd.filesJSON = buildFilesJSONPruned(files, scope.Keep)
 
-		// Build risks
-		cd.risksByPath = map[string][]riskItemForTpl{}
-		ra := analyzer.NewRiskAnalyzer()
-		for _, f := range files {
-			if !scope.keeps(f) {
-				continue
+	// Build risks
+	cd.risksByPath = map[string][]riskItemForTpl{}
+	ra := analyzer.NewRiskAnalyzer()
+	for _, f := range files {
+		if !scope.keeps(f) {
+			continue
+		}
+		items := ra.DetectFileRisks(f)
+		if len(items) > 0 {
+			converted := make([]riskItemForTpl, 0, len(items))
+			for _, it := range items {
+				converted = append(converted, riskItemForTpl{ID: it.ID, Title: it.Title, Severity: it.Severity, Details: it.Details})
 			}
-			items := ra.DetectFileRisks(f)
-			if len(items) > 0 {
-				converted := make([]riskItemForTpl, 0, len(items))
-				for _, it := range items {
-					converted = append(converted, riskItemForTpl{ID: it.ID, Title: it.Title, Severity: it.Severity, Details: it.Details})
-				}
-				cd.risksByPath[f.Path] = converted
-			}
+			cd.risksByPath[f.Path] = converted
 		}
-		cd.risksJSON = buildRisksJSON(cd.risksByPath, dict)
-
-		// Community
-		currentView := scope.View
-		cd.nodeToCommunityJSON = "{}"
-		if currentView.Community != nil && len(currentView.Community.NodeToCommunity) > 0 {
-			cd.nodeToCommunityJSON = buildNodeToCommunityJSON(currentView.Community.NodeToCommunity)
-		}
-
-		cd.testQualityJSON = "{}"
-		if currentView.TestQuality != nil {
-			cd.testQualityJSON = analyzer.BuildTestQualityJSON(currentView.TestQuality)
-		}
-
-		cd.fileDepsJSON = buildFileDepsJSON(currentView.FileDependencies, dict)
-
-		// Count files for this scope
-		fileCount := 0
-		for _, f := range files {
-			if !scope.keeps(f) {
-				continue
-			}
-			fileCount++
-		}
-		cd.depFileCount = fileCount
-
-		// Build folder-level deps for dependency graph folder view
-		cd.folderDepsJSON = buildFolderDepsJSON(currentView.ConcernedFiles, currentView.FileDependencies, dict)
-
-		cd.dictionaryJSON = dict.ToJSON()
 	}
+	cd.risksJSON = buildRisksJSON(cd.risksByPath, dict)
+
+	// Community
+	currentView := scope.View
+	cd.nodeToCommunityJSON = "{}"
+	if currentView.Community != nil && len(currentView.Community.NodeToCommunity) > 0 {
+		cd.nodeToCommunityJSON = buildNodeToCommunityJSON(currentView.Community.NodeToCommunity)
+	}
+
+	cd.testQualityJSON = "{}"
+	if currentView.TestQuality != nil {
+		cd.testQualityJSON = analyzer.BuildTestQualityJSON(currentView.TestQuality)
+	}
+
+	cd.fileDepsJSON = buildFileDepsJSON(currentView.FileDependencies, dict)
+
+	// Count files for this scope
+	fileCount := 0
+	for _, f := range files {
+		if !scope.keeps(f) {
+			continue
+		}
+		fileCount++
+	}
+	cd.depFileCount = fileCount
+
+	// Build folder-level deps for dependency graph folder view
+	cd.folderDepsJSON = buildFolderDepsJSON(currentView.ConcernedFiles, currentView.FileDependencies, dict)
+
+	cd.dictionaryJSON = dict.ToJSON()
 
 	return cd
 }
@@ -253,38 +251,36 @@ func (v *HtmlReportGenerator) prepareScopeData(scope scopeDef, files []*pb.File)
 // writeScopeData writes the data file the pages of one scope load, so that the
 // JSON is not duplicated in every page.
 func (v *HtmlReportGenerator) writeScopeData(dataDir string, dataKey string, cd *cachedLangData) error {
-	{
-		var jsBuilder strings.Builder
-		jsBuilder.WriteString("window.__AST_DATA__={")
-		jsBuilder.WriteString("files:")
-		jsBuilder.WriteString(cd.filesJSON)
-		jsBuilder.WriteString(",risks:")
-		jsBuilder.WriteString(cd.risksJSON)
-		jsBuilder.WriteString(",dictionary:")
-		jsBuilder.WriteString(cd.dictionaryJSON)
-		jsBuilder.WriteString(",fileDeps:")
-		if cd.fileDepsJSON == "" || cd.fileDepsJSON == "{}" {
-			jsBuilder.WriteString("{}")
-		} else {
-			jsBuilder.WriteString(cd.fileDepsJSON)
-		}
-		jsBuilder.WriteString(",folderDeps:")
-		if cd.folderDepsJSON == "" {
-			jsBuilder.WriteString("null")
-		} else {
-			jsBuilder.WriteString(cd.folderDepsJSON)
-		}
-		jsBuilder.WriteString(",depFileCount:")
-		jsBuilder.WriteString(fmt.Sprintf("%d", cd.depFileCount))
-		jsBuilder.WriteString(",nodeToCommunity:")
-		jsBuilder.WriteString(cd.nodeToCommunityJSON)
-		jsBuilder.WriteString(",testQuality:")
-		jsBuilder.WriteString(cd.testQualityJSON)
-		jsBuilder.WriteString("};")
-		dataFile := fmt.Sprintf("%s/data_%s.js", dataDir, dataKey)
-		if err := os.WriteFile(dataFile, []byte(jsBuilder.String()), 0644); err != nil {
-			return err
-		}
+	var jsBuilder strings.Builder
+	jsBuilder.WriteString("window.__AST_DATA__={")
+	jsBuilder.WriteString("files:")
+	jsBuilder.WriteString(cd.filesJSON)
+	jsBuilder.WriteString(",risks:")
+	jsBuilder.WriteString(cd.risksJSON)
+	jsBuilder.WriteString(",dictionary:")
+	jsBuilder.WriteString(cd.dictionaryJSON)
+	jsBuilder.WriteString(",fileDeps:")
+	if cd.fileDepsJSON == "" || cd.fileDepsJSON == "{}" {
+		jsBuilder.WriteString("{}")
+	} else {
+		jsBuilder.WriteString(cd.fileDepsJSON)
+	}
+	jsBuilder.WriteString(",folderDeps:")
+	if cd.folderDepsJSON == "" {
+		jsBuilder.WriteString("null")
+	} else {
+		jsBuilder.WriteString(cd.folderDepsJSON)
+	}
+	jsBuilder.WriteString(",depFileCount:")
+	jsBuilder.WriteString(fmt.Sprintf("%d", cd.depFileCount))
+	jsBuilder.WriteString(",nodeToCommunity:")
+	jsBuilder.WriteString(cd.nodeToCommunityJSON)
+	jsBuilder.WriteString(",testQuality:")
+	jsBuilder.WriteString(cd.testQualityJSON)
+	jsBuilder.WriteString("};")
+	dataFile := fmt.Sprintf("%s/data_%s.js", dataDir, dataKey)
+	if err := os.WriteFile(dataFile, []byte(jsBuilder.String()), 0644); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/report/html_report_generator.go
+++ b/internal/report/html_report_generator.go
@@ -1184,8 +1184,9 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 			rowsToKeep = param.Integer()
 		}
 
-		// Sort by risk of file
-		files := in.Interface().([]*pb.File)
+		// Sort a copy: the backing array is shared with the other pages,
+		// which are rendered in parallel
+		files := append([]*pb.File(nil), in.Interface().([]*pb.File)...)
 		sort.Slice(files, func(i, j int) bool {
 			if files[i].Stmts == nil && files[j].Stmts == nil || files[i].Stmts == nil || files[j].Stmts == nil || files[i].Stmts.Analyze == nil || files[j].Stmts.Analyze == nil {
 				return false
@@ -1226,8 +1227,9 @@ func (v *HtmlReportGenerator) RegisterFilters() {
 			return pongo2.AsValue([]interface{}{}), nil
 		}
 
-		// Sort by risk of file first (reuse logic)
-		files := in.Interface().([]*pb.File)
+		// Sort a copy: the backing array is shared with the other pages,
+		// which are rendered in parallel
+		files := append([]*pb.File(nil), in.Interface().([]*pb.File)...)
 		sort.Slice(files, func(i, j int) bool {
 			if files[i] == nil || files[j] == nil || files[i].Stmts == nil || files[j].Stmts == nil || files[i].Stmts.Analyze == nil || files[j].Stmts.Analyze == nil {
 				return false

--- a/internal/report/html_report_generator.go
+++ b/internal/report/html_report_generator.go
@@ -8,8 +8,10 @@ import (
 	"hash/fnv"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -145,10 +147,54 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 	// programming language, then one per analyzed directory (CLI argument).
 	scopeDefs := buildScopes(files, projectAggregated)
 
-	// Pre-compute JSON data once per scope to avoid redundant work across pages
+	// Pre-compute JSON data once per scope to avoid redundant work across pages.
+	//
+	// A scope reads the files and writes only its own entry, and encoding the
+	// files of a scope to JSON is the longest part of the report, so the scopes
+	// are prepared in parallel and collected in order afterwards.
 	v.langCache = make(map[string]*cachedLangData)
-	for _, scope := range scopeDefs {
-		cd := &cachedLangData{}
+	prepared := make([]*cachedLangData, len(scopeDefs))
+
+	var scopeGroup sync.WaitGroup
+	for index, scope := range scopeDefs {
+		scopeGroup.Add(1)
+		go func(index int, scope scopeDef) {
+			defer scopeGroup.Done()
+			prepared[index] = v.prepareScopeData(scope, files)
+		}(index, scope)
+	}
+	scopeGroup.Wait()
+
+	for index, scope := range scopeDefs {
+		v.langCache[scope.DataKey] = prepared[index]
+	}
+
+	// Write shared data JS files (one per scope) to avoid duplicating JSON in every HTML page
+	dataDir := fmt.Sprintf("%s/data", v.ReportPath)
+	err = v.EnsureFolder(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	for dataKey, cd := range v.langCache {
+		if err := v.writeScopeData(dataDir, dataKey, cd); err != nil {
+			return nil, err
+		}
+	}
+
+	// Write shared linter data file (one copy for all languages, dictionary-encoded)
+	linterJS := buildLinterDataJS(projectAggregated.Evaluation)
+	if err := os.WriteFile(fmt.Sprintf("%s/linters.js", dataDir), []byte(linterJS), 0644); err != nil {
+		return nil, err
+	}
+
+	return v.generatePages(baseTemplateDir, scopeDefs, files, projectAggregated)
+}
+
+// prepareScopeData builds everything a scope's pages read: its files as JSON,
+// its risks, its communities, its dependencies.
+func (v *HtmlReportGenerator) prepareScopeData(scope scopeDef, files []*pb.File) *cachedLangData {
+	cd := &cachedLangData{}
+	{
 		dict := NewStringDictionary()
 
 		cd.filesJSON = buildFilesJSONPruned(files, scope.Keep)
@@ -199,17 +245,15 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		cd.folderDepsJSON = buildFolderDepsJSON(currentView.ConcernedFiles, currentView.FileDependencies, dict)
 
 		cd.dictionaryJSON = dict.ToJSON()
-
-		v.langCache[scope.DataKey] = cd
 	}
 
-	// Write shared data JS files (one per scope) to avoid duplicating JSON in every HTML page
-	dataDir := fmt.Sprintf("%s/data", v.ReportPath)
-	err = v.EnsureFolder(dataDir)
-	if err != nil {
-		return nil, err
-	}
-	for dataKey, cd := range v.langCache {
+	return cd
+}
+
+// writeScopeData writes the data file the pages of one scope load, so that the
+// JSON is not duplicated in every page.
+func (v *HtmlReportGenerator) writeScopeData(dataDir string, dataKey string, cd *cachedLangData) error {
+	{
 		var jsBuilder strings.Builder
 		jsBuilder.WriteString("window.__AST_DATA__={")
 		jsBuilder.WriteString("files:")
@@ -239,18 +283,22 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		jsBuilder.WriteString("};")
 		dataFile := fmt.Sprintf("%s/data_%s.js", dataDir, dataKey)
 		if err := os.WriteFile(dataFile, []byte(jsBuilder.String()), 0644); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	// Write shared linter data file (one copy for all languages, dictionary-encoded)
-	linterJS := buildLinterDataJS(projectAggregated.Evaluation)
-	if err := os.WriteFile(fmt.Sprintf("%s/linters.js", dataDir), []byte(linterJS), 0644); err != nil {
-		return nil, err
-	}
+	return nil
+}
 
-	// One page per template, for every scope (all / language / directory)
-	for _, template := range []string{
+// generatePages renders every page of every scope, and copies what they load.
+func (v *HtmlReportGenerator) generatePages(baseTemplateDir string, scopeDefs []scopeDef, files []*pb.File, projectAggregated analyzer.ProjectAggregated) ([]GeneratedReport, error) {
+	// One page per template, for every scope (all / language / directory).
+	//
+	// A page reads the aggregates and the cache built above, and writes a file
+	// of its own, so the pages are rendered in parallel: a project with three
+	// scopes renders three dozen of them, and rendering them one after the other
+	// was the second longest phase of an analysis.
+	pageTemplates := []string{
 		"index.html",
 		"risks.html",
 		"explorer.html",
@@ -263,16 +311,28 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 		"busfactor.html",
 		"testquality.html",
 		"classification.html",
-	} {
-		for _, scope := range scopeDefs {
-			// errors are logged by GenerateScopePage: a single broken page must
-			// not discard the whole report
-			v.GenerateScopePage(template, scope, scopeDefs, files, projectAggregated)
-		}
 	}
 
+	var pages sync.WaitGroup
+	slots := make(chan struct{}, runtime.NumCPU())
+	for _, template := range pageTemplates {
+		for _, scope := range scopeDefs {
+			pages.Add(1)
+			go func(template string, scope scopeDef) {
+				defer pages.Done()
+				slots <- struct{}{}
+				defer func() { <-slots }()
+
+				// errors are logged by GenerateScopePage: a single broken page
+				// must not discard the whole report
+				v.GenerateScopePage(template, scope, scopeDefs, files, projectAggregated)
+			}(template, scope)
+		}
+	}
+	pages.Wait()
+
 	// copy images
-	err = v.EnsureFolder(fmt.Sprintf("%s/images", v.ReportPath))
+	err := v.EnsureFolder(fmt.Sprintf("%s/images", v.ReportPath))
 	if err != nil {
 		return nil, err
 	}
@@ -842,8 +902,10 @@ func countFiles(files []*pb.File, keep fileFilter) int {
 
 func (v *HtmlReportGenerator) GenerateScopePage(template string, scope scopeDef, scopes []scopeDef, files []*pb.File, projectAggregated analyzer.ProjectAggregated) error {
 
-	// Compile the index.html template
-	tpl, err := pongo2.DefaultSet.FromFile(template)
+	// The same template is rendered once per scope, so it is compiled once and
+	// kept: FromCache is thread-safe and caches by filename, FromFile parses the
+	// file and its layout again on every call.
+	tpl, err := pongo2.DefaultSet.FromCache(template)
 	if err != nil {
 		log.Error(err)
 		return err

--- a/internal/report/html_report_generator.go
+++ b/internal/report/html_report_generator.go
@@ -151,7 +151,8 @@ func (v *HtmlReportGenerator) Generate(files []*pb.File, projectAggregated analy
 	//
 	// A scope reads the files and writes only its own entry, and encoding the
 	// files of a scope to JSON is the longest part of the report, so the scopes
-	// are prepared in parallel and collected in order afterwards.
+	// are prepared in parallel and collected in order afterwards: the order of
+	// the entries must not depend on which scope finishes first.
 	v.langCache = make(map[string]*cachedLangData)
 	prepared := make([]*cachedLangData, len(scopeDefs))
 
@@ -292,8 +293,8 @@ func (v *HtmlReportGenerator) generatePages(baseTemplateDir string, scopeDefs []
 	//
 	// A page reads the aggregates and the cache built above, and writes a file
 	// of its own, so the pages are rendered in parallel: a project with three
-	// scopes renders three dozen of them, and rendering them one after the other
-	// was the second longest phase of an analysis.
+	// scopes renders three dozen of them, enough to make the report the second
+	// longest phase of an analysis when they are rendered one at a time.
 	pageTemplates := []string{
 		"index.html",
 		"risks.html",


### PR DESCRIPTION
The latest changes (metrics stabilisation during last weeks) made ast-metrics slower.

This (big) PR optimises the hot spots. For example:

- terminal output was really slow: we checked what the CLI environment supports on every single output
- N+1 file reads in the Halstead visitors (the whole file was re-read for every function)
- excluded directories were walked during file discovery instead of  being skipped
- the HTML report pages are now rendered in parallel

It also fixes a data race that the parallel rendering exposed.
