### PR TITLE
fix(python): count a triple-quoted string as a comment only when it is a bare statement

### DIFF
--- a/internal/engine/comments.go
+++ b/internal/engine/comments.go
@@ -49,6 +49,14 @@ type CommentSyntax struct {
 	// and C#'s `"""` text block. Its lines are code, and a comment marker
 	// written inside it is part of the value, not a comment.
 	RawString []string
+	// IsDocString, when set, decides whether the DocString delimiter opening
+	// at the start of the given 1-based line is documentation. A triple-quoted
+	// string alone on its line is not always a docstring: black formats a
+	// multi-line argument or tuple member as `(` on one line and `"""` on the
+	// next, and a test fixture or SQL query written that way is a value the
+	// program carries. Only a parser knows which one it is, so the adapter
+	// answers from the AST; when nil, the delimiter is taken as documentation.
+	IsDocString func(line int) bool
 	// LetterPrefixedStrings tells that a string literal may carry a prefix of
 	// letters, as Python writes r"", b"", f"" and their combinations. Without
 	// it, a raw docstring `r"""..."""` would not be recognised as one.
@@ -126,6 +134,8 @@ type scanner struct {
 	openComment string
 	// openString holds the token that closes the multi-line string in progress.
 	openString string
+	// line is the 1-based number of the line being classified.
+	line int
 }
 
 // classify returns what the line holds, and advances the scanner state.
@@ -186,6 +196,11 @@ func (s *scanner) opensComment(line string) bool {
 	// a raw string standing at the start of a line is a value, not
 	// documentation: only a comment block and a documentation string are
 	if kind != delimiterComment && kind != delimiterDoc {
+		return false
+	}
+	if kind == delimiterDoc && s.syn.IsDocString != nil && !s.syn.IsDocString(s.line) {
+		// the parser says this string is a value, not the documentation of
+		// what follows: the line is code, and so is the rest of the string
 		return false
 	}
 
@@ -341,6 +356,7 @@ func NewLineIndex(sourceCode []string, syn CommentSyntax) *LineIndex {
 
 	s := &scanner{syn: syn}
 	for i, line := range sourceCode {
+		s.line = i + 1
 		cloc, ncloc := idx.cloc[i], idx.ncloc[i]
 		switch s.classify(line) {
 		case lineComment:

--- a/internal/engine/python/python_runner_test.go
+++ b/internal/engine/python/python_runner_test.go
@@ -297,3 +297,48 @@ func TestPythonFloorDivisionIsNotAComment(t *testing.T) {
 		t.Errorf("expected 5 logical lines, got %d", fn.LinesOfCode.LogicalLinesOfCode)
 	}
 }
+
+// A triple-quoted string standing alone on its line is not always a docstring:
+// black writes a multi-line argument or tuple member as `(` on one line and
+// `"""` alone on the next. Only the string written as a statement of its own
+// documents something; the others are values, hence code.
+func TestPythonTripleQuotedValueIsNotAComment(t *testing.T) {
+	src := `"""Module docstring."""
+
+CASES = [
+    (
+        '''
+        if a: pass
+        ''',
+        2,
+    ),
+]
+
+def f(a):
+    """Doc of f."""
+    q = textwrap.dedent(
+        """
+        SELECT 1
+        FROM t
+        """
+    )
+    return q
+`
+	r := &PythonRunner{}
+	file, err := enginePkg.CreateTestFileWithCode(r, src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	// the module docstring and the docstring of f, nothing else
+	if got := file.LinesOfCode.CommentLinesOfCode; got != 2 {
+		t.Errorf("expected 2 comment lines in the file, got %d", got)
+	}
+	fn := file.Stmts.StmtNamespace[0].Stmts.StmtFunction[0]
+	if got := fn.LinesOfCode.CommentLinesOfCode; got != 1 {
+		t.Errorf("expected 1 comment line in f, got %d", got)
+	}
+	// the assignment and the return; the query is part of the assignment
+	if got := fn.LinesOfCode.LogicalLinesOfCode; got != 2 {
+		t.Errorf("expected 2 logical lines in f, got %d", got)
+	}
+}

--- a/internal/engine/python/tree_sitter_python_adapter.go
+++ b/internal/engine/python/tree_sitter_python_adapter.go
@@ -13,12 +13,15 @@ import (
 type TreeSitterAdapter struct {
 	src  []byte
 	root *sitter.Node
+	// docStringLines holds the 1-based lines on which a bare string
+	// expression begins, computed once from the tree on first use.
+	docStringLines map[int]bool
 }
 
 func NewTreeSitterAdapter(src []byte) *TreeSitterAdapter { return &TreeSitterAdapter{src: src} }
 
 func (a *TreeSitterAdapter) SetSource(src []byte)          { a.src = src }
-func (a *TreeSitterAdapter) SetRootNode(root *sitter.Node) { a.root = root }
+func (a *TreeSitterAdapter) SetRootNode(root *sitter.Node) { a.root = root; a.docStringLines = nil }
 
 func (a *TreeSitterAdapter) NodeName(n *sitter.Node) string {
 	if a.src == nil || n == nil {
@@ -417,15 +420,58 @@ func (a *TreeSitterAdapter) Statement(n *sitter.Node) Treesitter.StatementKind {
 
 // CommentSyntax declares Python comment tokens: "#" starts a comment, "//" is
 // the floor division operator and "/* */" does not exist. A triple-quoted
-// string is the docstring of what follows it, so it is documentation, exactly
-// like a docblock in the other languages.
+// string written as a statement of its own is the docstring of what follows
+// it, so it is documentation, exactly like a docblock in the other languages.
+// The same string written as a value (a fixture in a tuple, a query passed to
+// a call) is code, and only the tree tells the two apart, black having taught
+// everyone to write `(` on one line and `"""` alone on the next.
 func (a *TreeSitterAdapter) CommentSyntax() engine.CommentSyntax {
 	return engine.CommentSyntax{
-		Line:      []string{"#"},
-		DocString: []string{`"""`, `'''`},
-		Quote:     []rune{'"', '\''},
+		Line:        []string{"#"},
+		DocString:   []string{`"""`, `'''`},
+		Quote:       []rune{'"', '\''},
+		IsDocString: a.isDocStringLine,
 		// a docstring may be raw or formatted: r"""...""", f"""..."""
 		LetterPrefixedStrings: true,
+	}
+}
+
+// isDocStringLine reports whether the string opening at the start of the given
+// 1-based line is a bare string expression: the docstring of a module, class or
+// function, or a string dropped as a statement anywhere else, which the LLOC
+// model leaves out for the same reason. Without a tree to ask, every
+// triple-quoted string standing alone on its line is documentation, as before.
+func (a *TreeSitterAdapter) isDocStringLine(line int) bool {
+	if a.docStringLines == nil {
+		root := a.root
+		if root == nil {
+			if a.src == nil {
+				return true
+			}
+			parser := sitter.NewParser()
+			parser.SetLanguage(a.Language())
+			root = parser.Parse(nil, a.src).RootNode()
+		}
+		a.docStringLines = map[int]bool{}
+		collectDocStringLines(root, a.docStringLines)
+	}
+	return a.docStringLines[line]
+}
+
+// collectDocStringLines records the starting line of every expression_statement
+// made of a single string.
+func collectDocStringLines(n *sitter.Node, lines map[int]bool) {
+	if n == nil {
+		return
+	}
+	if n.Type() == "expression_statement" {
+		if Treesitter.IsStringExpression(n, "string", "concatenated_string") {
+			lines[int(n.StartPoint().Row)+1] = true
+		}
+		return
+	}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		collectDocStringLines(n.NamedChild(i), lines)
 	}
 }
 


### PR DESCRIPTION
A triple-quoted string standing alone on its line was always counted as a docstring, hence as comment lines. black writes a multi-line argument or tuple member as `(` on one line and `"""` alone on the next, so test fixtures, SQL queries and templates inflated CLOC and the maintainability index (radon's `test_complexity_visitor.py`: 314 comment lines out of 754 instead of 7, MI 85 instead of ~42).

The comment scanner now accepts an `IsDocString(line)` predicate, and the Python adapter answers from the tree: only an `expression_statement` made of a single string is documentation, the same rule the LLOC model already applies.

Checked against radon on `requests` and `radon` (47 files): CLOC now matches on every fixture-heavy file, and the remaining differences are within the noise of inline `#` comments.