### PR TITLE
fix(tui): nil-safety in class table and stable language menu ordering

### DIFF
--- a/internal/cli/component_class_table.go
+++ b/internal/cli/component_class_table.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ast-metrics/ast-metrics/internal/engine"
+	pb "github.com/ast-metrics/ast-metrics/pb"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/ast-metrics/ast-metrics/internal/engine"
-	pb "github.com/ast-metrics/ast-metrics/pb"
 )
 
 type ComponentTableClass struct {
@@ -118,7 +118,7 @@ func (v *ComponentTableClass) Init() {
 
 		for _, class := range classes {
 
-			if class == nil {
+			if class == nil || class.Name == nil {
 				continue
 			}
 
@@ -142,39 +142,26 @@ func (v *ComponentTableClass) Init() {
 				nbFunctions = len(class.Stmts.StmtFunction)
 			}
 
+			analyze := class.Stmts.Analyze
+			volume := analyze.GetVolume()
+			complexity := analyze.GetComplexity()
+			maintainability := analyze.GetMaintainability()
+			maintainabilityIndex := float64(0)
+			if maintainability != nil && maintainability.MaintainabilityIndex != nil {
+				maintainabilityIndex = maintainability.GetMaintainabilityIndex()
+			}
+
 			rows = append(rows, table.Row{
 				class.Name.Qualified,
 				strconv.Itoa(nbCommits),
 				strconv.Itoa(nbCommitters),
 				strconv.Itoa(nbFunctions),
-				strconv.Itoa(int(*class.Stmts.Analyze.Volume.Loc)),
-				strconv.Itoa(int(*class.Stmts.Analyze.Complexity.Cyclomatic)),
-				strconv.Itoa(int(*class.Stmts.Analyze.Volume.HalsteadLength)),
-				fmt.Sprintf("%.2f", ToFixed(*class.Stmts.Analyze.Volume.HalsteadVolume, 2)),
-				DecorateMaintainabilityIndex(int(*class.Stmts.Analyze.Maintainability.MaintainabilityIndex), class.Stmts.Analyze),
+				strconv.Itoa(int(volume.GetLoc())),
+				strconv.Itoa(int(complexity.GetCyclomatic())),
+				strconv.Itoa(int(volume.GetHalsteadLength())),
+				fmt.Sprintf("%.2f", ToFixed(volume.GetHalsteadVolume(), 2)),
+				DecorateMaintainabilityIndex(int(maintainabilityIndex), analyze),
 			})
-		}
-
-		for _, namespace := range file.Stmts.StmtNamespace {
-			for _, class := range namespace.Stmts.StmtClass {
-
-				if class == nil {
-					continue
-				}
-				if class.Stmts == nil {
-					continue
-				}
-
-				rows = append(rows, table.Row{
-					class.Name.Qualified,
-					strconv.Itoa(len(class.Stmts.StmtFunction)),
-					strconv.Itoa(int(*class.Stmts.Analyze.Volume.Loc)),
-					strconv.Itoa(int(*class.Stmts.Analyze.Complexity.Cyclomatic)),
-					strconv.Itoa(int(*class.Stmts.Analyze.Volume.HalsteadLength)),
-					fmt.Sprintf("%.2f", ToFixed(*class.Stmts.Analyze.Volume.HalsteadVolume, 2)),
-					DecorateMaintainabilityIndex(int(*class.Stmts.Analyze.Maintainability.MaintainabilityIndex), class.Stmts.Analyze),
-				})
-			}
 		}
 	}
 

--- a/internal/cli/component_table_class_test.go
+++ b/internal/cli/component_table_class_test.go
@@ -5,6 +5,7 @@ import (
 
 	pb "github.com/ast-metrics/ast-metrics/pb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewComponentTableClass(t *testing.T) {
@@ -84,6 +85,32 @@ func TestComponentTableClass_Render(t *testing.T) {
 
 	assert.Contains(t, rendered, "Use arrows to navigate and esc to quit", "Help is present")
 	assert.Contains(t, rendered, "ClassA", "ClassA is present")
+}
+
+func TestComponentTableClassHandlesMissingClassMetrics(t *testing.T) {
+	files := []*pb.File{{
+		Path: "forward.hpp",
+		Stmts: &pb.Stmts{
+			StmtClass: []*pb.StmtClass{{
+				Name:  &pb.Name{Qualified: "Forward", Short: "Forward"},
+				Stmts: &pb.Stmts{Analyze: &pb.Analyze{}},
+			}},
+			StmtNamespace: []*pb.StmtNamespace{{
+				Stmts: &pb.Stmts{StmtClass: []*pb.StmtClass{{
+					Name:  &pb.Name{Qualified: "Forward", Short: "Forward"},
+					Stmts: &pb.Stmts{Analyze: &pb.Analyze{}},
+				}}},
+			}},
+		},
+	}}
+
+	component := NewComponentTableClass(false, files)
+	require.Len(t, component.table.Rows(), 1, "namespace and file views of a class must not be duplicated")
+	row := component.table.Rows()[0]
+	require.Len(t, row, 9)
+	assert.Equal(t, "Forward", row[0])
+	assert.Equal(t, "0", row[4])
+	assert.Equal(t, "0.00", row[7])
 }
 
 func TestComponentTableClass_Sort(t *testing.T) {

--- a/internal/cli/screen_by_programming_langage.go
+++ b/internal/cli/screen_by_programming_langage.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"fmt"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	pb "github.com/ast-metrics/ast-metrics/pb"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type ScreenByProgrammingLanguage struct {
@@ -76,6 +76,8 @@ func (v ScreenByProgrammingLanguage) GetScreenName() string {
 		emoji = "☕ "
 	case "C#":
 		emoji = "🟦 "
+	case "C++":
+		emoji = "🔷 "
 	}
 
 	count := 0

--- a/internal/cli/screen_by_programming_language_test.go
+++ b/internal/cli/screen_by_programming_language_test.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"testing"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	pb "github.com/ast-metrics/ast-metrics/pb"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestScreenByProgrammingLanguageGetScreenName(t *testing.T) {
@@ -22,6 +22,22 @@ func TestScreenByProgrammingLanguageGetScreenName(t *testing.T) {
 	got := screen.GetScreenName()
 
 	if got != expected {
+		t.Errorf("Expected %s, got %s", expected, got)
+	}
+}
+
+func TestScreenByProgrammingLanguageGetScreenNameCpp(t *testing.T) {
+	screen := ScreenByProgrammingLanguage{
+		programmingLangageName: "C++",
+		files: []*pb.File{
+			{ProgrammingLanguage: "C++"},
+			{ProgrammingLanguage: "C++"},
+			{ProgrammingLanguage: "Golang"},
+		},
+	}
+
+	expected := "🔷 C++ (2 files)"
+	if got := screen.GetScreenName(); got != expected {
 		t.Errorf("Expected %s, got %s", expected, got)
 	}
 }

--- a/internal/cli/screen_home.go
+++ b/internal/cli/screen_home.go
@@ -3,11 +3,12 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
 
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/fsnotify/fsnotify"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	pb "github.com/ast-metrics/ast-metrics/pb"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/fsnotify/fsnotify"
 	"github.com/muesli/termenv"
 )
 
@@ -140,8 +141,15 @@ func fillInScreens(modelChoices *modelChoices) {
 		&viewRisks,
 	}
 
-	// Append one screen per programming language
-	for languageName, lang := range modelChoices.projectAggregated.ByProgrammingLanguage {
+	// Append one screen per programming language. Go deliberately randomizes map
+	// iteration, so sort the names to keep menu positions stable across renders.
+	languageNames := make([]string, 0, len(modelChoices.projectAggregated.ByProgrammingLanguage))
+	for languageName := range modelChoices.projectAggregated.ByProgrammingLanguage {
+		languageNames = append(languageNames, languageName)
+	}
+	sort.Strings(languageNames)
+	for _, languageName := range languageNames {
+		lang := modelChoices.projectAggregated.ByProgrammingLanguage[languageName]
 		viewByProgrammingLanguage := ScreenByProgrammingLanguage{isInteractive: true}
 		viewByProgrammingLanguage.programmingLangageName = languageName
 		viewByProgrammingLanguage.programmingLangageAggregated = lang

--- a/internal/cli/screen_home_test.go
+++ b/internal/cli/screen_home_test.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"testing"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/ast-metrics/ast-metrics/internal/analyzer"
 	pb "github.com/ast-metrics/ast-metrics/pb"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,5 +45,27 @@ func TestInit(t *testing.T) {
 
 	if cmd != nil {
 		t.Errorf("Expected cmd to be nil, but got %v", cmd)
+	}
+}
+
+func TestFillInScreensSortsProgrammingLanguages(t *testing.T) {
+	project := analyzer.ProjectAggregated{ByProgrammingLanguage: map[string]analyzer.Aggregated{
+		"Python": {},
+		"C++":    {},
+		"Golang": {},
+	}}
+
+	for range 20 {
+		model := modelChoices{projectAggregated: project}
+		fillInScreens(&model)
+		assert.Len(t, model.screens, 6)
+		languages := make([]string, 0, 3)
+		for _, screen := range model.screens[3:] {
+			languageScreen, ok := screen.(*ScreenByProgrammingLanguage)
+			if assert.True(t, ok) {
+				languages = append(languages, languageScreen.programmingLangageName)
+			}
+		}
+		assert.Equal(t, []string{"C++", "Golang", "Python"}, languages)
 	}
 }


### PR DESCRIPTION
## Summary

Extracted from #183 — these are standalone TUI fixes that were discovered while adding C++ support but affect all languages.

### Changes

- **Class table nil-safety** (`component_class_table.go`): Classes that lack a maintainability index (e.g. forward declarations) previously caused a nil-pointer crash. Now renders safely as zero.
- **Remove duplicate namespace rows** (`component_class_table.go`): Classes inside namespaces were traversed twice (once from the file-level class list, once from the namespace), producing duplicate malformed rows. Now uses the shared `GetClassesInFile` helper for a single pass.
- **Stable language menu ordering** (`screen_home.go`): Go deliberately randomizes map iteration, so the per-language menu items bounced around on every keypress. Now sorts language names before building the menu.
- **C++ icon** (`screen_by_programming_langage.go`): Adds the C++ emoji to the language menu, ready for when C++ support lands.

### Tests

- Regression test for nil class metrics and deduplication (`TestComponentTableClassHandlesMissingClassMetrics`)
- Regression test for stable sort order over 20 iterations (`TestFillInScreensSortsProgrammingLanguages`)
- Test for C++ screen name rendering (`TestScreenByProgrammingLanguageGetScreenNameCpp`)

All 30 CLI tests pass.